### PR TITLE
Fix open_flash_chart install so that redmine_charts2 plugin can render charts

### DIFF
--- a/assets/setup/plugins/install
+++ b/assets/setup/plugins/install
@@ -48,7 +48,7 @@ mkdir -p /redmine/plugins/open_flash_chart
 tar -zvxf /redmine/setup/plugins/open_flash_chart.tar.gz --strip=1 -C /redmine/plugins/open_flash_chart
 
 mkdir -p /redmine/public/plugin_assets/open_flash_chart
-cp -r /redmine/plugins/open_flash_chart/assets /redmine/public/plugin_assets/open_flash_chart
+cp -r /redmine/plugins/open_flash_chart/assets/* /redmine/public/plugin_assets/open_flash_chart
 
 # redmine charts2 plugin
 # wget https://github.com/pharmazone/redmine_charts2/archive/redmine21.tar.gz -O redmine_charts21.tar.gz


### PR DESCRIPTION
Copy contents of assets directory, not the directory itself. Fixes the redmine_charts2 functionality.
