### PR TITLE
added REDMINE_RELATIVE_URL_ROOT configuration option

### DIFF
--- a/assets/config/config.ru
+++ b/assets/config/config.ru
@@ -1,0 +1,10 @@
+# This file is used by Rack-based servers to start the application.
+
+require ::File.expand_path('../config/environment',  __FILE__)
+if ENV['RAILS_RELATIVE_URL_ROOT']
+  map ENV['RAILS_RELATIVE_URL_ROOT'] do
+    run RedmineApp::Application
+  end
+else
+  run RedmineApp::Application
+end

--- a/assets/config/nginx/redmine
+++ b/assets/config/nginx/redmine
@@ -8,7 +8,7 @@ upstream redmine {
 server {
   listen *:80 default_server;
   server_tokens off;
-  root /redmine/public;
+  root /dev/null;
 
   # Increase this if you want to upload large attachments
   # Or if you want to accept large git objects over http
@@ -18,7 +18,8 @@ server {
   access_log  /var/log/nginx/redmine_access.log;
   error_log   /var/log/nginx/redmine_error.log;
 
-  location / {
+  location {{REDMINE_RELATIVE_URL_ROOT}}/ {
+    root /redmine/public;
     # serve static files from defined root folder;.
     # @redmine is a named location for the upstream fallback, see below
     try_files $uri $uri/index.html $uri.html @redmine;

--- a/assets/config/redmine/unicorn.rb
+++ b/assets/config/redmine/unicorn.rb
@@ -17,7 +17,7 @@
 # 4) In ../gitlab-shell/config.yml: gitlab_url: "http://127.0.0.1/gitlab"
 # To update the path, run: sudo -u git -H bundle exec rake assets:precompile RAILS_ENV=production
 #
-# ENV['RAILS_RELATIVE_URL_ROOT'] = "/gitlab"
+# ENV['RAILS_RELATIVE_URL_ROOT'] = "{{REDMINE_RELATIVE_URL_ROOT}}"
 
 # Use at least one worker per core if you're on a dedicated server,
 # more will usually help for _short_ waits on databases/caches.

--- a/assets/init
+++ b/assets/init
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+REDMINE_RELATIVE_URL_ROOT=${REDMINE_RELATIVE_URL_ROOT:-}
+
 DB_HOST=${DB_HOST:-}
 DB_PORT=${DB_PORT:-}
 DB_NAME=${DB_NAME:-redmine_production}
@@ -158,6 +160,13 @@ sed 's/{{NGINX_MAX_UPLOAD_SIZE}}/'"${NGINX_MAX_UPLOAD_SIZE}"'/' -i /etc/nginx/si
 # configure unicorn
 sudo -u www-data -H sed 's/{{UNICORN_WORKERS}}/'"${UNICORN_WORKERS}"'/' -i config/unicorn.rb
 sudo -u www-data -H sed 's/{{UNICORN_TIMEOUT}}/'"${UNICORN_TIMEOUT}"'/' -i config/unicorn.rb
+
+# configure relative_url_root
+sudo -u root -H sed 's,{{REDMINE_RELATIVE_URL_ROOT}},'"${REDMINE_RELATIVE_URL_ROOT}"',' -i /etc/nginx/sites-available/redmine
+if [ ${REDMINE_RELATIVE_URL_ROOT} ]; then
+	sudo -u www-data -H cp -f setup/config/config.ru config.ru
+	sudo -u root -H sed "s,# ENV\['RAILS_RELATIVE_URL_ROOT'\] = \"{{REDMINE_RELATIVE_URL_ROOT}}\",ENV\['RAILS_RELATIVE_URL_ROOT'\] = \"${REDMINE_RELATIVE_URL_ROOT}\"," -i config/unicorn.rb
+fi
 
 # configure mail delivery
 sudo -u www-data -H sed 's/{{SMTP_HOST}}/'"${SMTP_HOST}"'/' -i config/initializers/smtp_settings.rb


### PR DESCRIPTION
Hi,

I added "REDMINE_RELATIVE_URL_ROOT" configuration option just like your docker-gitlab for driving the Redmine on sub-URL like http://localhost/redmine/.
