### PR TITLE
Fix SMTP Authentification not exist in smtp config

### DIFF
--- a/assets/config/redmine/smtp_settings.rb
+++ b/assets/config/redmine/smtp_settings.rb
@@ -8,7 +8,7 @@ if Rails.env.production?
     :domain               => "{{SMTP_DOMAIN}}",
     :user_name            => "{{SMTP_USER}}",
     :password             => "{{SMTP_PASS}}",
-    :authentication       => :login,
+    :authentication       => {{SMTP_AUTHENTICATION}},
     :enable_starttls_auto => {{SMTP_STARTTLS}}
   }
 end


### PR DESCRIPTION
Forget {{}} in smtp file and :login not replaced by init script
