### PR TITLE
fix ownership issue with /redmine/files/VERSION

### DIFF
--- a/assets/init
+++ b/assets/init
@@ -195,7 +195,7 @@ appStart () {
 	[ -f /redmine/files/VERSION ] && CURRENT_VERSION=$(cat /redmine/files/VERSION)
 	if [ "$DB_INIT" == "yes" -o "${REDMINE_VERSION}" != "${CURRENT_VERSION}" ]; then
 		appDbMigrate
-		sudo -u www-data -H echo "${REDMINE_VERSION}" > /redmine/files/VERSION
+		echo "${REDMINE_VERSION}" | sudo -u www-data -H tee /redmine/files/VERSION >/dev/null
 	fi
 
 	echo "Generating secure token..."


### PR DESCRIPTION
Running echo under sudo does not change the user who opens the redirect file, as that's the parent shell that sets that up before calling sudo.

For writing to privileged files with sudo, I've most often seen this construct which uses tee.  Since tee is started under sudo, it can open the privileged file and copy what it receives on stdin into it.
