### PR TITLE
add ability to use SSL in nginx

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 **latest**
+- added NGINX_CERT and NGINX_KEY configuration options to enable SSL
 - update to the sameersbn/ubuntu:12.04.20140812 baseimage
 - automatically migrate the database when the redmine version changes
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ ADD assets/init /redmine/init
 RUN chmod 755 /redmine/init
 
 EXPOSE 80
+EXPOSE 443
 VOLUME ["/redmine/files"]
 ENTRYPOINT ["/redmine/init"]
 CMD ["app:start"]

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
             - [External PostgreSQL Server](#external-postgresql-server)
             - [Linking to PostgreSQL Container](#linking-to-postgresql-container)
     - [Mail](#mail)
+    - [Using SSL](#using-ssl)
     - [Putting it all together](#putting-it-all-together)
     - [Available Configuration Parameters](#available-configuration-parameters)
 - [Upgrading](#upgrading)
@@ -343,6 +344,17 @@ __NOTE:__
 
 I have only tested standard gmail and google apps login. I expect that the currently provided configuration parameters should be sufficient for most users. If this is not the case, then please let me know.
 
+### Using SSL
+
+To enable SSL, you must make a certificate and key available to nginx and pass their locations when running the container.
+
+```
+docker run --name redmine -d -h redmine.local.host \
+  -v /opt/redmine/certs:/redmine/certs \
+  -e "NGINX_CERT=/redmine/certs/ssl-cert-snakeoil.pem" -e "NGINX_KEY=/redmine/certs/ssl-cert-snakeoil.key" \
+  ...
+```
+
 ### Putting it all together
 
 ```
@@ -377,6 +389,8 @@ Below is the complete list of parameters that can be set using environment varia
 - **DB_PASS**: The database password. Defaults to no password
 - **DB_POOL**: The database connection pool count. Defaults to 5.
 - **NGINX_MAX_UPLOAD_SIZE**: Maximum acceptable upload size. Defaults to 20m.
+- **NGINX_CERT**: The path to the PEM-format SSL certificate to use.
+- **NGINX_KEY**: The path to the SSL certificate's private key.
 - **UNICORN_WORKERS**: The number of unicorn workers to start. Defaults to 2.
 - **UNICORN_TIMEOUT**: Sets the timeout of unicorn worker processes. Defaults to 60 seconds.
 - **MEMCACHED_SIZE**: The local memcached size in Mb. Defaults to 64. Disabled if '0'.

--- a/assets/config/nginx/redmine-ssl
+++ b/assets/config/nginx/redmine-ssl
@@ -1,0 +1,42 @@
+# GCOSIGN
+# Maintainer: @sameersbn
+
+server {
+  listen *:443 default_server;
+  server_tokens off;
+  root /redmine/public;
+
+  ssl on;
+  ssl_certificate {{NGINX_CERT}};
+  ssl_certificate_key {{NGINX_KEY}};
+
+  # Increase this if you want to upload large attachments
+  # Or if you want to accept large git objects over http
+  client_max_body_size {{NGINX_MAX_UPLOAD_SIZE}};
+
+  # individual nginx logs for this redmine vhost
+  access_log  /var/log/nginx/redmine_access.log;
+  error_log   /var/log/nginx/redmine_error.log;
+
+  location / {
+    # serve static files from defined root folder;.
+    # @redmine is a named location for the upstream fallback, see below
+    try_files $uri $uri/index.html $uri.html @redmine;
+  }
+
+  # if a file, which is not found in the root folder is requested,
+  # then the proxy pass the request to the upsteam (redmine unicorn)
+  location @redmine {
+    proxy_read_timeout 300;
+    proxy_connect_timeout 300;
+    proxy_redirect off;
+
+    proxy_set_header   X-Forwarded-Proto $scheme;
+    proxy_set_header   Host              $http_host;
+    proxy_set_header   X-Real-IP         $remote_addr;
+    proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+
+    proxy_pass http://redmine;
+  }
+  error_page 500 /500.html;
+}

--- a/assets/init
+++ b/assets/init
@@ -95,6 +95,7 @@ chown www-data:www-data /redmine/files
 
 cd /redmine
 cp setup/config/nginx/redmine /etc/nginx/sites-available/redmine
+cp setup/config/nginx/redmine-ssl /etc/nginx/sites-available/redmine-ssl
 sudo -u www-data -H cp setup/config/redmine/additional_environment.rb config/additional_environment.rb
 sudo -u www-data -H cp setup/config/redmine/database.yml config/database.yml
 sudo -u www-data -H cp setup/config/redmine/unicorn.rb config/unicorn.rb
@@ -105,6 +106,7 @@ if [ -d /redmine/data/config ]; then
   chown -R www-data /redmine/data/config
   cd /redmine/data/config
   [ -f nginx/redmine ]                      && cp nginx/redmine /etc/nginx/sites-available/redmine
+  [ -f nginx/redmine-ssl ]                      && cp nginx/redmine /etc/nginx/sites-available/redmine-ssl
   [ -f redmine/additional_environment.rb ]  && sudo -u www-data -H cp redmine/additional_environment.rb /redmine/config/additional_environment.rb
   [ -f redmine/database.yml ]               && sudo -u www-data -H cp redmine/database.yml              /redmine/config/database.yml
   [ -f redmine/unicorn.rb ]                 && sudo -u www-data -H cp redmine/unicorn.rb                /redmine/config/unicorn.rb
@@ -145,8 +147,21 @@ else
   sudo -u www-data -H sed 's/{{ENABLE_CACHE}}/false/' -i config/additional_environment.rb
 fi
 
-# configure nginx
+# configure nginx max upload size
 sed 's/{{NGINX_MAX_UPLOAD_SIZE}}/'"${NGINX_MAX_UPLOAD_SIZE}"'/' -i /etc/nginx/sites-available/redmine
+sed 's/{{NGINX_MAX_UPLOAD_SIZE}}/'"${NGINX_MAX_UPLOAD_SIZE}"'/' -i /etc/nginx/sites-available/redmine-ssl
+
+# if certificate and key are specified, modify the default ssl config
+if [ -n "${NGINX_CERT}" -a -r "${NGINX_CERT}" -a -n "${NGINX_KEY}" -a -r "${NGINX_KEY}" ]; then
+  sed 's|{{NGINX_CERT}}|'"${NGINX_CERT}"'|' -i /etc/nginx/sites-available/redmine-ssl
+  sed 's|{{NGINX_KEY}}|'"${NGINX_KEY}"'|' -i /etc/nginx/sites-available/redmine-ssl
+fi
+
+# if ssl config has a certificate and key, enable it
+rm -f /etc/nginx/sites-enabled/redmine-ssl
+if ! grep -E '{NGINX_KEY|NGINX_CERT}' /etc/nginx/sites-available/redmine-ssl >/dev/null 2>&1; then
+  ln -s /etc/nginx/sites-available/redmine-ssl /etc/nginx/sites-enabled/redmine-ssl
+fi
 
 # configure unicorn
 sudo -u www-data -H sed 's/{{UNICORN_WORKERS}}/'"${UNICORN_WORKERS}"'/' -i config/unicorn.rb


### PR DESCRIPTION
This adds the ability to volume mount a certificate and key, point a couple of environment variables at them, and have nginx serve both http and https sites.  The README has been updated with an example of how to do that.  It seems to be fairly robust, in that, if you stop the container, delete cert files, and restart the container, it enables just the http site.  But, if you stop it, put the cert files back (or replace them with others), then restart, the ssl site is back.
