### PR TITLE
add domain socket ability for DB conn

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 **latest**
+- added DB_SOCK config option for Unix-domain database connection
 - update to the sameersbn/ubuntu:12.04.20140812 baseimage
 - automatically migrate the database when the redmine version changes
 

--- a/assets/config/redmine/domainsocket.yml
+++ b/assets/config/redmine/domainsocket.yml
@@ -1,0 +1,9 @@
+production:
+  adapter: "{{DB_ADAPTER}}"
+  encoding: "{{DB_ENCODING}}"
+  reconnect: false
+  database: "{{DB_NAME}}"
+  socket: "{{DB_SOCK}}"
+  username: "{{DB_USER}}"
+  password: "{{DB_PASS}}"
+  pool: {{DB_POOL}}

--- a/assets/init
+++ b/assets/init
@@ -52,8 +52,8 @@ esac
 # start supervisord
 /usr/bin/supervisord
 
-# start mysql server if ${DB_HOST} is localhost
-if [ "${DB_HOST}" == "localhost" ]; then
+# start mysql server if ${DB_HOST} is localhost and not using Unix-domain socket
+if [ ! -S "${DB_SOCK}" -a "${DB_HOST}" == "localhost" ]; then
   if [ "${DB_TYPE}" == "postgres" ]; then
     echo "DB_TYPE 'postgres' is not supported internally. Please provide DB_HOST."
     exit 1
@@ -114,6 +114,9 @@ fi
 cd /redmine
 
 # configure database
+if [ -S "${DB_SOCK}" ]; then
+	sudo -u www-data -H cp setup/config/redmine/domainsocket.yml config/database.yml
+fi
 if [ "${DB_TYPE}" == "postgres" ]; then
   sudo -u www-data -H sed 's/{{DB_ADAPTER}}/postgresql/' -i config/database.yml
   sudo -u www-data -H sed 's/{{DB_ENCODING}}/unicode/' -i config/database.yml
@@ -126,6 +129,7 @@ else
   echo "Invalid database type: '$DB_TYPE'. Supported choices: [mysql, postgres]."
 fi
 
+sudo -u www-data -H sed 's|{{DB_SOCK}}|'"${DB_SOCK}"'|' -i config/database.yml
 sudo -u www-data -H sed 's/{{DB_HOST}}/'"${DB_HOST}"'/' -i config/database.yml
 sudo -u www-data -H sed 's/{{DB_PORT}}/'"${DB_PORT}"'/' -i config/database.yml
 sudo -u www-data -H sed 's/{{DB_NAME}}/'"${DB_NAME}"'/' -i config/database.yml


### PR DESCRIPTION
This allows the container to use a host's DB server via its Unix-domain socket rather than its IP.  It involves sharing the socket file via a volume mount, and specifying the path within the container to that socket via the DB_SOCK environment variable.

Note: I've tested this with MySQL and it works very well.  The logic is there for PostgreSQL as well, but I have not tested it.

This pull request is also re-based to your latest commits to master.  It merges with the use-ssl pull request with only the Changelog.md lines conflicting.
