### PR TITLE
add domain socket ability for DB connections

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 **latest**
+- added DB_SOCK config option for Unix-domain database connection
 - added new SMTP_ENABLED configuration option. Fixes #30
 - moved data volume path to /home/redmine/data
 - added REDMINE_RELATIVE_URL_ROOT configuration option (thanks to @k-kagurazaka)

--- a/README.md
+++ b/README.md
@@ -11,9 +11,11 @@
         - [MySQL](#mysql)
             - [Internal MySQL Server](#internal-mysql-server)
             - [External MySQL Server](#external-mysql-server)
+            - [MySQL Server on Host](#mysql-server-on-host)
             - [Linking to MySQL Container](#linking-to-mysql-container)
         - [PostgreSQL](#postgresql)
             - [External PostgreSQL Server](#external-postgresql-server)
+            - [PostgreSQL Server on Host](#postgresql-server-on-host)
             - [Linking to PostgreSQL Container](#linking-to-postgresql-container)
     - [Mail](#mail)
     - [Putting it all together](#putting-it-all-together)
@@ -202,6 +204,40 @@ docker run --name=redmine -it --rm \
 
 This will initialize the redmine database and after a couple of minutes your redmine instance should be ready to use.
 
+#### MySQL Server on Host
+Because a docker container cannot access the localhost interface on its host, to connect to a MySQL server running on the host, you have to either bind the listening port to a specific externally available IP, or to 0.0.0.0.  If you would rather not do that, you can connect to it via Unix-domain socket.  This is done by bind-mounting the socket as a volume, and specifying the DB_SOCK environment variable rather than the DB_HOST (and DB_PORT).
+
+Before you start the Redmine image create user and database for redmine.
+
+```
+mysql -uroot -p
+CREATE USER 'redmine'@'localhost' IDENTIFIED BY 'password';
+CREATE DATABASE IF NOT EXISTS `redmine_production` DEFAULT CHARACTER SET `utf8` COLLATE `utf8_unicode_ci`;
+GRANT SELECT, LOCK TABLES, INSERT, UPDATE, DELETE, CREATE, DROP, INDEX, ALTER ON `redmine_production`.* TO 'redmine'@'localhost';
+```
+ 
+Now that we have the database created for redmine, lets install the database schema. This is done by starting the redmine container with the **app:db:migrate** command.
+
+```
+docker run --name redmine -it --rm \
+  -v /var/run/mysqld/mysqld.sock:/tmp/mysqld.sock -e "DB_SOCK=/tmp/mysqld.sock" \
+  -e "DB_NAME=redmine_production" -e "DB_USER=redmine" -e "DB_PASS=password" \
+  -v /opt/redmine/files:/redmine/files sameersbn/redmine:2.5.2 app:db:migrate
+```
+
+**NOTE: The above setup is performed only for the first run**.
+
+We are now ready to start the redmine application.
+
+```
+docker run --name redmine -d \
+  -v /var/run/mysqld/mysqld.sock:/tmp/mysqld.sock -e "DB_SOCK=/tmp/mysqld.sock" \
+  -e "DB_NAME=redmine_production" -e "DB_USER=redmine" -e "DB_PASS=password" \
+  -v /opt/redmine/files:/redmine/files sameersbn/redmine:2.5.2
+```
+
+This will initialize the redmine database and after a couple of minutes your redmine instance should be ready to use.
+
 #### Linking to MySQL Container
 
 You can link this image with a mysql container for the database requirements. The alias of the mysql server container should be set to **mysql** while linking with the redmine image.
@@ -303,6 +339,39 @@ docker run --name=redmine -it --rm \
   -e "DB_TYPE=postgres" -e "DB_HOST=192.168.1.100" \
   -e "DB_NAME=redmine_production" -e "DB_USER=redmine" -e "DB_PASS=password" \
   -v /opt/redmine/data:/home/redmine/data \
+  sameersbn/redmine:2.5.2
+```
+
+This will initialize the redmine database and after a couple of minutes your redmine instance should be ready to use.
+
+#### PostgreSQL Server on Host
+Because a docker container cannot access the localhost interface on its host, to connect to a PostgreSQL server running on the host, you have to either bind the listening port to a specific externally available IP, or to 0.0.0.0.  If you would rather not do that, you can connect to it via Unix-domain socket.  This is done by bind-mounting the socket as a volume, and specifying the DB_SOCK environment variable rather than the DB_HOST (and DB_PORT).
+
+```sql
+CREATE ROLE redmine with LOGIN CREATEDB PASSWORD 'password';
+CREATE DATABASE redmine_production;
+GRANT ALL PRIVILEGES ON DATABASE redmine_production to redmine;
+```
+
+Now that we have the database created for redmine, lets install the database schema. This is done by starting the redmine container with the **app:db:migrate** command.
+
+```bash
+docker run --name redmine -it --rm -e "DB_TYPE=postgres" \
+  -v /var/pgsql_socket/.s.PGSQL.5432:/tmp/.s.PGSQL.5432 -e "DB_SOCK=/tmp/.s.PGSQL.5432" \
+  -e "DB_NAME=redmine_production" -e "DB_USER=redmine" -e "DB_PASS=password" \
+  -v /opt/redmine/files:/redmine/files \
+  sameersbn/redmine:2.5.2 app:db:migrate
+```
+
+**NOTE: The above setup is performed only for the first run**.
+
+We are now ready to start the redmine application.
+
+```bash
+docker run --name redmine -d -e "DB_TYPE=postgres" \
+  -v /var/pgsql_socket/.s.PGSQL.5432:/tmp/.s.PGSQL.5432 -e "DB_SOCK=/tmp/.s.PGSQL.5432" \
+  -e "DB_NAME=redmine_production" -e "DB_USER=redmine" -e "DB_PASS=password" \
+  -v /opt/redmine/files:/redmine/files \
   sameersbn/redmine:2.5.2
 ```
 
@@ -434,6 +503,7 @@ Below is the complete list of parameters that can be set using environment varia
 
 - **DB_TYPE**: The database type. Possible values: `mysql`, `postgres`. Defaults to `mysql`.
 - **DB_HOST**: The database server hostname. Defaults to `localhost`.
+- **DB_SOCK**: The path to the host DB server's Unix-domain socket. Supercedes DB_HOST if defined.
 - **DB_PORT**: The database server port. Defaults to `3306`.
 - **DB_NAME**: The database name. Defaults to `redmine_production`
 - **DB_USER**: The database user. Defaults to `root`

--- a/assets/config/redmine/domainsocket.yml
+++ b/assets/config/redmine/domainsocket.yml
@@ -1,0 +1,9 @@
+production:
+  adapter: "{{DB_ADAPTER}}"
+  encoding: "{{DB_ENCODING}}"
+  reconnect: false
+  database: "{{DB_NAME}}"
+  socket: "{{DB_SOCK}}"
+  username: "{{DB_USER}}"
+  password: "{{DB_PASS}}"
+  pool: {{DB_POOL}}

--- a/assets/init
+++ b/assets/init
@@ -13,6 +13,7 @@ REDMINE_RELATIVE_URL_ROOT=${REDMINE_RELATIVE_URL_ROOT:-}
 
 DB_HOST=${DB_HOST:-}
 DB_PORT=${DB_PORT:-}
+DB_SOCK=${DB_SOCK:-}
 DB_NAME=${DB_NAME:-redmine_production}
 DB_USER=${DB_USER:-root}
 DB_PASS=${DB_PASS:-}
@@ -73,8 +74,8 @@ chown redmine:redmine ${DATA_DIR}
 # container using --volumes-from)
 chmod +x ${DATA_DIR}
 
-# start mysql server if ${DB_HOST} is localhost
-if [ "${DB_HOST}" == "localhost" ]; then
+# start mysql server if ${DB_HOST} is localhost and not using Unix-domain socket
+if [ ! -S "${DB_SOCK}" -a "${DB_HOST}" == "localhost" ]; then
   if [ "${DB_TYPE}" == "postgres" ]; then
     echo "DB_TYPE 'postgres' is not supported internally. Please provide DB_HOST."
     exit 1
@@ -130,6 +131,9 @@ sudo -u redmine -H cp ${SYSCONF_TEMPLATES_DIR}/redmine/smtp_settings.rb config/i
 [ -f ${USERCONF_TEMPLATES_DIR}/redmine/smtp_settings.rb ]          && sudo -u redmine -H cp ${USERCONF_TEMPLATES_DIR}/redmine/smtp_settings.rb config/initializers/smtp_settings.rb
 
 # configure database
+if [ -S "${DB_SOCK}" ]; then
+  sudo -u www-data -H cp setup/config/redmine/domainsocket.yml config/database.yml
+fi
 if [ "${DB_TYPE}" == "postgres" ]; then
   sudo -u redmine -H sed 's/{{DB_ADAPTER}}/postgresql/' -i config/database.yml
   sudo -u redmine -H sed 's/{{DB_ENCODING}}/unicode/' -i config/database.yml
@@ -142,6 +146,7 @@ else
   echo "Invalid database type: '$DB_TYPE'. Supported choices: [mysql, postgres]."
 fi
 
+sudo -u redmine -H sed 's|{{DB_SOCK}}|'"${DB_SOCK}"'|' -i config/database.yml
 sudo -u redmine -H sed 's/{{DB_HOST}}/'"${DB_HOST}"'/' -i config/database.yml
 sudo -u redmine -H sed 's/{{DB_PORT}}/'"${DB_PORT}"'/' -i config/database.yml
 sudo -u redmine -H sed 's/{{DB_NAME}}/'"${DB_NAME}"'/' -i config/database.yml


### PR DESCRIPTION
This patch allows the container to access a DB running on the host through a volume mount of the host DB's Unix-domain socket.  This method is slightly faster than IP (and is the preferred method when specifying an IP of localhost anyway), and allows the host configuration to keep its listening interface on localhost rather than listening on an external IP or all interfaces.

Some caveats:  This patch has not been tested since the many recent changes to the base image.  This patch was developed before them, and was recently rebased to the new changes.  While the merge was successful (with updates to the README.md and Changelog.md files), the implications of the recent base image changes have not been fully analyzed.

This had been tested before the recent changes using only a MySQL instance on the container's host.  While the ability to use PostgreSQL on the host exists, and this patch should support it, the author has not had the opportunity to test it with PostgreSQL.

Please also review the updates to the README.md file to make sure they are in the right place and reflect any updates to human procedures introduced in the recent changes.
