### PR TITLE
Add feature to enable SSL/TLS site via env params

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 **latest**
+- added REDMINE_HTTPS and associated configuration options
 - added new SMTP_ENABLED configuration option. Fixes #30
 - moved data volume path to /home/redmine/data
 - added REDMINE_RELATIVE_URL_ROOT configuration option (thanks to @k-kagurazaka)

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ ADD assets/init /app/init
 RUN chmod 755 /app/init
 
 EXPOSE 80
+EXPOSE 443
 
 VOLUME ["/home/redmine/data"]
 ENTRYPOINT ["/app/init"]

--- a/assets/config/nginx/redmine-redir
+++ b/assets/config/nginx/redmine-redir
@@ -1,0 +1,9 @@
+## This is a normal HTTP host which redirects all traffic to the HTTPS host.
+server {
+  listen *:80;
+  server_name _;
+  server_tokens off;
+  ## root doesn't have to be a valid path since we are redirecting
+  root /nowhere;
+  rewrite ^ https://$host:443$request_uri? permanent;
+}

--- a/assets/config/nginx/redmine-ssl
+++ b/assets/config/nginx/redmine-ssl
@@ -1,0 +1,62 @@
+# Redmine
+# Maintainer: @sameersbn
+
+upstream redmine {
+  server unix:{{INSTALL_DIR}}/tmp/sockets/redmine.socket fail_timeout=0;
+}
+
+server {
+  listen *:443 default_server;
+  server_tokens off;
+  root {{INSTALL_DIR}}/public;
+
+  ssl on;
+  ssl_certificate {{SSL_CERTIFICATE_PATH}};
+  ssl_certificate_key {{SSL_KEY_PATH}};
+
+  ssl_ciphers 'ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES256-GCM-SHA384:AES128-GCM-SHA256:AES256-SHA256:AES128-SHA256:AES256-SHA:AES128-SHA:DES-CBC3-SHA:HIGH:!aNULL:!eNULL:!EXPORT:!CAMELLIA:!DES:!MD5:!PSK:!RC4';
+
+  ssl_protocols  TLSv1 TLSv1.1 TLSv1.2;
+  ssl_session_cache  builtin:1000  shared:SSL:10m;
+  ssl_dhparam {{SSL_DHPARAM_PATH}};
+
+  ssl_prefer_server_ciphers   on;
+
+  add_header Strict-Transport-Security max-age=63072000;
+  add_header X-Content-Type-Options nosniff;
+
+  # Increase this if you want to upload large attachments
+  # Or if you want to accept large git objects over http
+  client_max_body_size {{NGINX_MAX_UPLOAD_SIZE}};
+
+  # individual nginx logs for this redmine vhost
+  access_log  /var/log/nginx/redmine_access.log;
+  error_log   /var/log/nginx/redmine_error.log;
+
+  location {{REDMINE_RELATIVE_URL_ROOT}} {
+    #alias {{INSTALL_DIR}}/public;
+    # serve static files from defined root folder;.
+    # @redmine is a named location for the upstream fallback, see below
+    try_files $uri $uri/index.html $uri.html @redmine;
+
+    ## If you use https make sure you disable gzip compression
+    ## to be safe against BREACH attack.
+    gzip off;
+  }
+
+  # if a file, which is not found in the root folder is requested,
+  # then the proxy pass the request to the upsteam (redmine unicorn)
+  location @redmine {
+    proxy_read_timeout 300;
+    proxy_connect_timeout 300;
+    proxy_redirect off;
+
+    proxy_set_header   X-Forwarded-Proto $scheme;
+    proxy_set_header   Host              $http_host;
+    proxy_set_header   X-Real-IP         $remote_addr;
+    proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+
+    proxy_pass http://redmine;
+  }
+  error_page 500 /500.html;
+}

--- a/assets/init
+++ b/assets/init
@@ -7,6 +7,7 @@ DATA_DIR="/home/redmine/data"
 
 SETUP_DIR="/app/setup"
 SYSCONF_TEMPLATES_DIR="${SETUP_DIR}/config"
+SSL_CERTIFICATES_DIR="${SETUP_DIR}/certs"
 USERCONF_TEMPLATES_DIR="${DATA_DIR}/config"
 
 REDMINE_RELATIVE_URL_ROOT=${REDMINE_RELATIVE_URL_ROOT:-}
@@ -34,6 +35,13 @@ fi
 SMTP_ENABLED=${SMTP_ENABLED:-false}
 
 NGINX_MAX_UPLOAD_SIZE=${NGINX_MAX_UPLOAD_SIZE:-20m}
+
+REDMINE_HTTPS=${REDMINE_HTTPS:-false}
+REDMINE_HTTPS_ONLY=${REDMINE_HTTPS_ONLY:-true}
+
+SSL_CERTIFICATE_PATH=${SSL_CERTIFICATE_PATH:-${SSL_CERTIFICATES_DIR}/redmine.pem}
+SSL_KEY_PATH=${SSL_KEY_PATH:-${SSL_CERTIFICATES_DIR}/redmine.key}
+SSL_DHPARAM_PATH=${SSL_DHPARAM_PATH:-${SSL_CERTIFICATES_DIR}/dhparam.pem}
 
 UNICORN_WORKERS=${UNICORN_WORKERS:-2}
 UNICORN_TIMEOUT=${UNICORN_TIMEOUT:-60}
@@ -115,6 +123,8 @@ cd ${INSTALL_DIR}
 
 # install default confuguration templates
 cp ${SYSCONF_TEMPLATES_DIR}/nginx/redmine /etc/nginx/sites-available/redmine
+cp ${SYSCONF_TEMPLATES_DIR}/nginx/redmine-ssl /etc/nginx/sites-available/redmine-ssl
+cp ${SYSCONF_TEMPLATES_DIR}/nginx/redmine-redir /etc/nginx/sites-available/redmine-redir
 sudo -u redmine -H cp ${SYSCONF_TEMPLATES_DIR}/redmine/additional_environment.rb config/additional_environment.rb
 sudo -u redmine -H cp ${SYSCONF_TEMPLATES_DIR}/redmine/database.yml config/database.yml
 sudo -u redmine -H cp ${SYSCONF_TEMPLATES_DIR}/redmine/unicorn.rb config/unicorn.rb
@@ -123,6 +133,8 @@ sudo -u redmine -H cp ${SYSCONF_TEMPLATES_DIR}/redmine/smtp_settings.rb config/i
 
 # override default configuration templates with user templates if available
 [ -f ${USERCONF_TEMPLATES_DIR}/nginx/redmine ]                     && cp ${USERCONF_TEMPLATES_DIR}/nginx/redmine /etc/nginx/sites-available/redmine
+[ -f ${USERCONF_TEMPLATES_DIR}/nginx/redmine-ssl ]                 && cp ${USERCONF_TEMPLATES_DIR}/nginx/redmine-ssl /etc/nginx/sites-available/redmine-ssl
+[ -f ${USERCONF_TEMPLATES_DIR}/nginx/redmine-redir ]               && cp ${USERCONF_TEMPLATES_DIR}/nginx/redmine-redir /etc/nginx/sites-available/redmine-redir
 [ -f ${USERCONF_TEMPLATES_DIR}/redmine/additional_environment.rb ] && sudo -u redmine -H cp ${USERCONF_TEMPLATES_DIR}/redmine/additional_environment.rb config/additional_environment.rb
 [ -f ${USERCONF_TEMPLATES_DIR}/redmine/database.yml ]              && sudo -u redmine -H cp ${USERCONF_TEMPLATES_DIR}/redmine/database.yml config/database.yml
 [ -f ${USERCONF_TEMPLATES_DIR}/redmine/unicorn.rb ]                && sudo -u redmine -H cp ${USERCONF_TEMPLATES_DIR}/redmine/unicorn.rb  config/unicorn.rb
@@ -161,9 +173,30 @@ else
   sudo -u redmine -H sed 's/{{ENABLE_CACHE}}/false/' -i config/additional_environment.rb
 fi
 
-# configure nginx
+# configure nginx max upload size, install, ssl paths
 sed 's/{{NGINX_MAX_UPLOAD_SIZE}}/'"${NGINX_MAX_UPLOAD_SIZE}"'/' -i /etc/nginx/sites-available/redmine
+sed 's/{{NGINX_MAX_UPLOAD_SIZE}}/'"${NGINX_MAX_UPLOAD_SIZE}"'/' -i /etc/nginx/sites-available/redmine-ssl
 sed 's,{{INSTALL_DIR}},'"${INSTALL_DIR}"',g' -i /etc/nginx/sites-available/redmine
+sed 's,{{INSTALL_DIR}},'"${INSTALL_DIR}"',g' -i /etc/nginx/sites-available/redmine-ssl
+sed 's,{{SSL_CERTIFICATE_PATH}},'"${SSL_CERTIFICATE_PATH}"',' -i /etc/nginx/sites-available/redmine-ssl
+sed 's,{{SSL_KEY_PATH}},'"${SSL_KEY_PATH}"',' -i /etc/nginx/sites-available/redmine-ssl
+
+# if dhparam path is valid, add to the config, otherwise remove the option
+if [ -r "${SSL_DHPARAM_PATH}" ]; then
+  sed 's,{{SSL_DHPARAM_PATH}},'"${SSL_DHPARAM_PATH}"',' -i /etc/nginx/sites-available/redmine-ssl
+else
+  sed '/ssl_dhparam: {{SSL_DHPARAM_PATH}};/d' -i /etc/nginx/sites-available/redmine-ssl
+fi
+
+# enable the sites as directed by variables
+if [ "${REDMINE_HTTPS}" == "true" ]; then
+  ln -s /etc/nginx/sites-available/redmine-ssl /etc/nginx/sites-enabled/redmine-ssl
+fi
+if [ "${REDMINE_HTTPS}" == "true" -a "${REDMINE_HTTPS_ONLY}" == "true" ]; then
+  ln -s /etc/nginx/sites-available/redmine-redir /etc/nginx/sites-enabled/redmine-redir
+else
+  ln -s /etc/nginx/sites-available/redmine /etc/nginx/sites-enabled/redmine
+fi
 
 # configure unicorn
 sudo -u redmine -H sed 's,{{INSTALL_DIR}},'"${INSTALL_DIR}"',g' -i config/unicorn.rb
@@ -175,10 +208,13 @@ if [ -n "${REDMINE_RELATIVE_URL_ROOT}" ]; then
   sudo -u redmine -H cp -f ${SYSCONF_TEMPLATES_DIR}/config.ru config.ru
   sudo -u redmine -H sed 's,{{REDMINE_RELATIVE_URL_ROOT}},'"${REDMINE_RELATIVE_URL_ROOT}"',' -i config/unicorn.rb
   sed 's,#alias '"${INSTALL_DIR}"'/public,alias '"${INSTALL_DIR}"'/public,' -i /etc/nginx/sites-available/redmine
+  sed 's,#alias '"${INSTALL_DIR}"'/public,alias '"${INSTALL_DIR}"'/public,' -i /etc/nginx/sites-available/redmine-ssl
   sed 's,{{REDMINE_RELATIVE_URL_ROOT}},'"${REDMINE_RELATIVE_URL_ROOT}"',' -i /etc/nginx/sites-available/redmine
+  sed 's,{{REDMINE_RELATIVE_URL_ROOT}},'"${REDMINE_RELATIVE_URL_ROOT}"',' -i /etc/nginx/sites-available/redmine-ssl
 else
   sudo -u redmine -H sed '/{{REDMINE_RELATIVE_URL_ROOT}}/d' -i config/unicorn.rb
   sed 's,{{REDMINE_RELATIVE_URL_ROOT}},/,' -i /etc/nginx/sites-available/redmine
+  sed 's,{{REDMINE_RELATIVE_URL_ROOT}},/,' -i /etc/nginx/sites-available/redmine-ssl
 fi
 
 if [ "${SMTP_ENABLED}" == "true" ]; then

--- a/assets/setup/install
+++ b/assets/setup/install
@@ -64,9 +64,8 @@ mkdir -p tmp tmp/pdf public/plugin_assets tmp/pids/ tmp/sockets/
 chmod -R u+rwX files log tmp
 chown -R redmine:redmine ${INSTALL_DIR}
 
-# disable default nginx configuration and enable redmine nginx configuration
+# disable default nginx configuration
 rm -f /etc/nginx/sites-enabled/default
-ln -s /etc/nginx/sites-available/redmine /etc/nginx/sites-enabled/redmine
 
 # setup log rotation for redmine
 cat > /etc/logrotate.d/redmine <<EOF


### PR DESCRIPTION
This feature allows nginx to export an HTTPS site in addition to (or redirected from) the HTTP site.

Note: This patch needs significant testing which I don't currently have the time to perform.  Since my initial testing, it has been heavily modified to conform to the syntax used on the sameersbn/docker-gitlab repository, and has not been fully tested with these changes.  It was also originally developed before the recent slew of changes to the sameersbn/docker-redmine repository.  Rather than hold on to it and need to rebase it yet again as the image evolves, I'm offering it as is in hopes that someone else can test it.

Although there's no mention in the README.md file of importing config files via a volume mount, I reused its parent directory to hold the certs directory with the intent of allowing a single volume mount to cover both scenarios.

I suggest testing with a volume mount of the certs to the default places as well as explicitly specifying the file locations via the SSL_*_PATH variables.  I would also test it with and without the DHPARAM file, and with all combinations of REDMINE_HTTPS and REDMINE_HTTPS_ONLY variables.

I borrowed heavily from the docker-gitlab repo's README verbiage, but removed much of the gitlab-specific certificate restrictions.  Please ensure what I copied and modified makes sense in the context of a redmine service.
