### PR TITLE
Add support for SSL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ ADD assets/init /app/init
 RUN chmod 755 /app/init
 
 EXPOSE 80
+EXPOSE 443
 
 VOLUME ["/home/redmine/data"]
 

--- a/assets/config/nginx/redmine-ssl
+++ b/assets/config/nginx/redmine-ssl
@@ -1,0 +1,53 @@
+# Redmine
+# Maintainer: @sameersbn
+
+upstream redmine {
+  server unix:{{INSTALL_DIR}}/tmp/sockets/redmine.socket fail_timeout=0;
+}
+
+server {
+  listen *:80 default_server;
+  server_name {{VHOST_NAME}};
+  return 301 https://$server_name$request_uri;
+}
+
+server {
+  listen *:443 default_server;
+  server_tokens off;
+  root {{INSTALL_DIR}}/public;
+
+  ssl    on;
+  ssl_certificate      {{DATA_DIR}}/ssl/redmine.pem;
+  ssl_certificate_key  {{DATA_DIR}}/ssl/redmine.key;
+
+  # Increase this if you want to upload large attachments
+  # Or if you want to accept large git objects over http
+  client_max_body_size {{NGINX_MAX_UPLOAD_SIZE}};
+
+  # individual nginx logs for this redmine vhost
+  access_log  /var/log/nginx/redmine_access.log;
+  error_log   /var/log/nginx/redmine_error.log;
+
+  location {{REDMINE_RELATIVE_URL_ROOT}} {
+    #alias {{INSTALL_DIR}}/public;
+    # serve static files from defined root folder;.
+    # @redmine is a named location for the upstream fallback, see below
+    try_files $uri $uri/index.html $uri.html @redmine;
+  }
+
+  # if a file, which is not found in the root folder is requested,
+  # then the proxy pass the request to the upsteam (redmine unicorn)
+  location @redmine {
+    proxy_read_timeout 300;
+    proxy_connect_timeout 300;
+    proxy_redirect off;
+
+    proxy_set_header   X-Forwarded-Proto $scheme;
+    proxy_set_header   Host              $http_host;
+    proxy_set_header   X-Real-IP         $remote_addr;
+    proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+
+    proxy_pass http://redmine;
+  }
+  error_page 500 /500.html;
+}

--- a/assets/init
+++ b/assets/init
@@ -35,6 +35,10 @@ SMTP_ENABLED=${SMTP_ENABLED:-false}
 
 NGINX_MAX_UPLOAD_SIZE=${NGINX_MAX_UPLOAD_SIZE:-20m}
 
+NGINX_SSL_ENABLED=${NGINX_SSL_ENABLED:-false}
+
+VHOST_NAME=${VHOST_NAME:-$(hostname -f)}
+
 UNICORN_WORKERS=${UNICORN_WORKERS:-2}
 UNICORN_TIMEOUT=${UNICORN_TIMEOUT:-60}
 
@@ -114,7 +118,11 @@ fi
 cd ${INSTALL_DIR}
 
 # install default confuguration templates
-cp ${SYSCONF_TEMPLATES_DIR}/nginx/redmine /etc/nginx/sites-available/redmine
+if [ "${NGINX_SSL_ENABLED}" == "true" ]; then
+  cp ${SYSCONF_TEMPLATES_DIR}/nginx/redmine-ssl /etc/nginx/sites-available/redmine
+else
+  cp ${SYSCONF_TEMPLATES_DIR}/nginx/redmine /etc/nginx/sites-available/redmine
+fi
 sudo -u redmine -H cp ${SYSCONF_TEMPLATES_DIR}/redmine/additional_environment.rb config/additional_environment.rb
 sudo -u redmine -H cp ${SYSCONF_TEMPLATES_DIR}/redmine/database.yml config/database.yml
 sudo -u redmine -H cp ${SYSCONF_TEMPLATES_DIR}/redmine/unicorn.rb config/unicorn.rb
@@ -164,6 +172,8 @@ fi
 # configure nginx
 sed 's/{{NGINX_MAX_UPLOAD_SIZE}}/'"${NGINX_MAX_UPLOAD_SIZE}"'/' -i /etc/nginx/sites-available/redmine
 sed 's,{{INSTALL_DIR}},'"${INSTALL_DIR}"',g' -i /etc/nginx/sites-available/redmine
+sed 's,{{DATA_DIR}},'"${DATA_DIR}"',g' -i /etc/nginx/sites-available/redmine
+sed 's,{{VHOST_NAME}},'"${VHOST_NAME}"',g' -i /etc/nginx/sites-available/redmine
 
 # configure unicorn
 sudo -u redmine -H sed 's,{{INSTALL_DIR}},'"${INSTALL_DIR}"',g' -i config/unicorn.rb


### PR DESCRIPTION
This commit adds support for reading an SSL certificate and redirecting 80 to 443.  I did not update any documentation.

I added these ENV options:

NGINX_SSL_ENABLED (defaults false, if true, uses for /home/redmine/data/ssl/redmine.pem and redmine.key)
VHOST_NAME (defaults to $(hostname -f), used it for the nginx redirect)

I added a config file named "redmine-ssl" which includes SSL-specific options.  If NGINX_SSL_ENABLED=true, it copies this instead of the normal redmine file.

My docker run command looked something like this:

docker run --name redmine -d -p IP:443:443 -p IP:80:80 -v /opt/redmine/files:/redmine/files -v /opt/redmine/ssl/:/home/redmine/data/ssl -h redmine.domain --env-file=/opt/redmine/ENV kstange/redmine

With ENV looking like this:

DB_HOST=db
DB_NAME=redmine
DB_USER=redmine
DB_PASS=redmine
SMTP_HOST=host
SMTP_PORT=25
SMTP_ENABLED=true
NGINX_SSL_ENABLED=true

I noticed that someone else submitted a pull request to enable SSL in a more complicated way, but I had trouble figuring out how to get his to work, especially because of apparent errors with his documentation updates.
