### PR TITLE
properly remove ssl_dhparam line from nginx config

### DIFF
--- a/assets/init
+++ b/assets/init
@@ -291,7 +291,7 @@ sed 's,{{SSL_KEY_PATH}},'"${SSL_KEY_PATH}"',' -i /etc/nginx/sites-enabled/redmin
 if [ -r "${SSL_DHPARAM_PATH}" ]; then
   sed 's,{{SSL_DHPARAM_PATH}},'"${SSL_DHPARAM_PATH}"',' -i /etc/nginx/sites-enabled/redmine
 else
-  sed '/ssl_dhparam: {{SSL_DHPARAM_PATH}};/d' -i /etc/nginx/sites-enabled/redmine
+  sed '/ssl_dhparam {{SSL_DHPARAM_PATH}};/d' -i /etc/nginx/sites-enabled/redmine
 fi
 
 if [ "${REDMINE_HTTPS_HSTS_ENABLED}" == "true" ]; then


### PR DESCRIPTION
In the case where no DH parameter is specified, a typo in `assets/init` was causing nginx site config to be left in a corrupt state. Nginx refuses to start:

```
2014/12/02 14:23:11 [emerg] 161#0: directive "ssl_dhparam" is not terminated by ";" in /etc/nginx/sites-enabled/redmine:60
```
