### PR TITLE
Add gsfonts for rendering gantt diagram

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv C3173AA6 \
       imagemagick subversion git cvs bzr mercurial rsync ruby2.1 locales openssh-client \
       gcc g++ make patch pkg-config ruby2.1-dev libc6-dev zlib1g-dev libxml2-dev \
       libmysqlclient18 libpq5 libyaml-0-2 libcurl3 libssl1.0.0 \
-      libxslt1.1 libffi6 zlib1g \
+      libxslt1.1 libffi6 zlib1g gsfonts \
  && update-locale LANG=C.UTF-8 LC_MESSAGES=POSIX \
  && gem install --no-document bundler \
  && rm -rf /var/lib/apt/lists/* # 20140918


### PR DESCRIPTION
```
Magick::ImageMagickError (unable to read font `/usr/share/fonts/type1/gsfonts/n019003l.pfb' @ error/annotate.c/RenderFreetype/1105: `(null)'):
  lib/redmine/helpers/gantt.rb:523:in `draw'
  lib/redmine/helpers/gantt.rb:523:in `to_image'
  app/controllers/gantts_controller.rb:44:in `block (2 levels) in show'
  app/controllers/gantts_controller.rb:42:in `show'
```