### PR TITLE
Support data volume and  let app:help show faster

### DIFF
--- a/assets/init
+++ b/assets/init
@@ -1,6 +1,25 @@
 #!/bin/bash
 set -e
 
+appHelp () {
+  echo "Available options:"
+  echo " app:start          - Starts the redmine server (default)"
+  echo " app:rake <task>    - Execute a rake task."
+  echo " app:help           - Displays the help"
+  echo " [command]          - Execute the specified linux command eg. bash."
+}
+
+case "$1" in
+  app:help)
+    appHelp
+    exit 0
+    ;;
+  app:volume)
+    echo "Create Redmine data volume."
+    exit 0
+    ;;
+esac
+
 HOME_DIR="/home/redmine"
 INSTALL_DIR="${HOME_DIR}/redmine"
 CONFIG_DIR="${INSTALL_DIR}/config"
@@ -498,14 +517,6 @@ appRake () {
   sudo -u redmine -H bundle exec rake $@ RAILS_ENV=production
 }
 
-appHelp () {
-  echo "Available options:"
-  echo " app:start          - Starts the redmine server (default)"
-  echo " app:rake <task>    - Execute a rake task."
-  echo " app:help           - Displays the help"
-  echo " [command]          - Execute the specified linux command eg. bash."
-}
-
 case "$1" in
   app:start)
     appStart
@@ -513,9 +524,6 @@ case "$1" in
   app:rake)
     shift 1
     appRake $@
-    ;;
-  app:help)
-    appHelp
     ;;
   *)
     if [ -x $1 ]; then


### PR DESCRIPTION
I'd like to use a data volume container instead of mount a local directory as the volume.
I used command like `docker run sameersbn/redmine echo "create redmine volume"` to create a cleaning data volume. Then I found database related variables must be set first which is useless when I just need a data volume. `docker run --rm sameersbn/redmine app:help` has the same issue.

I move appHelp to the beginning of init. I also add the app:volume as a option to just create a data volume.
Now I can use  `docker run --name redmine-volume sameersbn/redmine app:volume` to create a data volume.
And use command like  `docker run --link pg-redmine :postgresql --volumes-from redmine-volume -d sameersbn/redmine` to start a redmine.
Hope this can be useful to your guys.