### PR TITLE
Added Docker Labels from label-schema.org

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,18 @@ ENV REDMINE_INSTALL_DIR="${REDMINE_HOME}/redmine" \
     REDMINE_BUILD_DIR="${REDMINE_CACHE_DIR}/build" \
     REDMINE_RUNTIME_DIR="${REDMINE_CACHE_DIR}/runtime"
 
+# Basic build-time metadata as defined at http://label-schema.org
+ARG BUILD_DATE
+ARG VCS_REF
+LABEL org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.docker.dockerfile="/Dockerfile" \
+      org.label-schema.license="MIT" \
+      org.label-schema.name="Docker Redmine" \
+      org.label-schema.url="https://www.damagehead.com/docker-redmine/" \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.vcs-url="https://github.com/sameersbn/docker-redmine.git" \
+      org.label-schema.vcs-type="Git"
+
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv E1DD270288B4E6030699E45FA1715D88E1DF1F24 \
  && echo "deb http://ppa.launchpad.net/git-core/ppa/ubuntu trusty main" >> /etc/apt/sources.list \
  && apt-key adv --keyserver keyserver.ubuntu.com --recv 80F70E11F0F0D5F10CB20E62F5DA5F09C3173AA6 \

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,9 @@ help:
 	@echo "   5. make purge       - stop and remove the container"
 
 build:
-	@docker build --tag=sameersbn/redmine .
+	@docker build --tag=sameersbn/redmine \
+								--build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
+								--build-arg VCS_REF=`git rev-parse --short HEAD` .
 
 release:
 	@docker build --tag=sameersbn/redmine:$(shell cat VERSION) .


### PR DESCRIPTION
Hey Sameer! I'm working with some folks in the container community on a standard label schema. To get momentum we want to encourage as many people as possible to label their public container images.

To make it as easy as possible for you, here's a PR that will label your image automatically as part of your existing build process.

Once the labels are in place you could use MicroBadger (microbadger.com) to create image badges for jumping between your Docker Image and the appropriate commit on Github.

And if you're interested in getting involved with the label standardization, please jump on in at label-schema.org.
