### PR TITLE
Fix invalid parameter "spdy"

### DIFF
--- a/assets/runtime/config/nginx/redmine-ssl
+++ b/assets/runtime/config/nginx/redmine-ssl
@@ -18,8 +18,8 @@ server {
 
 ## HTTPS host
 server {
-  listen 0.0.0.0:443 ssl spdy;
-  listen [::]:443 ssl spdy default_server;
+  listen 0.0.0.0:443 ssl http2;
+  listen [::]:443 ssl http2 default_server;
   server_tokens off;
   root {{REDMINE_INSTALL_DIR}}/public;
 


### PR DESCRIPTION
Hey there, saw the following in the nginx logs. Apparently, spdy was replaced by http2.

```
invalid parameter "spdy": ngx_http_spdy_module was superseded by ngx_http_v2_module in /etc/nginx/sites-enabled/redmine:21
```
