### PR TITLE
Increase proxy buffer size to avoid nginx "upstream sent too big header"

### DIFF
--- a/assets/runtime/config/nginx/redmine
+++ b/assets/runtime/config/nginx/redmine
@@ -36,6 +36,10 @@ server {
     proxy_read_timeout      300;
     proxy_connect_timeout   300;
     proxy_redirect          off;
+    ## Long issue filters require increasing proxy buffers
+    proxy_buffers 8 8k;
+    proxy_buffer_size 32k;
+    proxy_busy_buffers_size 32k;
 
     proxy_set_header    Host                $http_host;
     proxy_set_header    X-Real-IP           $remote_addr;

--- a/assets/runtime/config/nginx/redmine-ssl
+++ b/assets/runtime/config/nginx/redmine-ssl
@@ -83,6 +83,10 @@ server {
     proxy_read_timeout      300;
     proxy_connect_timeout   300;
     proxy_redirect          off;
+    ## Long issue filters require increasing proxy buffers
+    proxy_buffers 8 8k;
+    proxy_buffer_size 32k;
+    proxy_busy_buffers_size 32k;
 
     proxy_set_header    Host                $http_host;
     proxy_set_header    X-Real-IP           $remote_addr;


### PR DESCRIPTION
Redmine gets nginx "502 bad gateway" error when using long issue filter and
using "right click assign to" on issue.  Increasing nginx proxy buffer size fixes this problem.

From nginx log
```
2017/01/17 09:54:55 [error] 261#261: *5514 upstream sent too big header while reading response header from upstream, client: 10.0.62.1, server: , request: "POST
/redmine/issues/bulk_update?back_url=%2Fredmine%2Fprojects%2Fquality%2Fissues%3Fc%255B%255D%3Dtracker%26c%255B%255D%3Dstatus%26c%255B%255D%3Dpriority%26c%255B%255D%3Dsubject%26c%255B%255D%3Dassigned_to%26c%255B%255D%3Dcategory%26c%255B%255D%3Ddue_date%26c%255B%255D%3Ddone_ratio%26f%255B%255D%3Dstatus_id%26f%255B%255D%3Dassigned_to_id%26f%255B%255D%3D%26group_by%3D%26op%255Bassigned_to_id%255D%3D%2521%26op%255Bstatus_id%255D%3Do%26set_filter%3D1%26t%255B%255D%3D%26utf8%3D%25E2%259C%2593%26v%255Bassigned_to_id%255D%255B%255D%3D150%26v%255Bassigned_to_id%255D%255B%255D%3D149%26v%255Bassigned_to_id%255D%255B%255D%3D99%26v%255Bassigned_to_id%255D%255B%255D%3D1420%26v%255Bassigned_to_id%255D%255B%255D%3D1466%26v%255Bassigned_to_id%255D%255B%255D%3D713%26v%255Bassigned_to_id%255D%255B%255D%3D379%26v%255Bassigned_to_id%255D%255B%255D%3D514%26v%255Bassigned_to_id%255D%255B%255D%3D760%26v%255Bassigned_to_id%255D%255B%255D%3D1490%26v%255Bassigned_to_id%255D%255B%255D%3D1465%26v%255Bassigned_to_id%255D%255B%255D%3D1461%26v%255Bassigned_to_id%255D%255B%255D%3D200%26v%255Bassigned_to_id%255D%255B%255D%3D106%26v%255Bassigned_to_id%255D%255B%255D%3D15%26v%255Bassigned_to_id%255D%255B%255D%3D1488%26v%255Bassigned_to_id%255D%255B%255D%3D20%26v%255Bassigned_to_id%255D%255B%255D%3D148%26v%255Bassigned_to_id%255D%255B%255D%3D64%26v%255Bassigned_to_id%255D%255B%255D%3D191%26v%255Bassigned_to_id%255D%255B%255D%3D849%26v%255Bassigned_to_id%255D%255B%255D%3D90%26v%255Bassigned_to_id%255D%255B%255D%3D1494%26v%255Bassigned_to_id%255D%255B%255D%3D199%26v%255Bassigned_to_id%255D%255B%255D%3D682%26v%255Bassigned_to_id%255D%255B%255D%3D170%26v%255Bassigned_to_id%255D%255B%255D%3D17%26v%255Bassigned_to_id%255D%255B%255D%3D360%26v%255Bassigned_to_id%255D%255B%255D%3D1493%26v%255Bassigned_to_id%255D%255B%255D%3D3%26v%255Bassigned_to_id%255D%255B%255D%3D1464%26v%255Bassigned_to_id%255D%25"
```