### PR TITLE
Remove TZ variable from docker-compose example

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,8 +15,6 @@ services:
     depends_on:
     - postgresql
     environment:
-    - TZ=Asia/Kolkata
-
     - DB_ADAPTER=postgresql
     - DB_HOST=postgresql
     - DB_PORT=5432


### PR DESCRIPTION
sameersbn/docker-redmine#256

TZ variable causes incoming email timestamps to be set incorrectly. Without this
set timestamps in database should be stored as UTC.