### PR TITLE
Add mysql version of docker-compose.yml

### DIFF
--- a/docker-compose-mysql.yml
+++ b/docker-compose-mysql.yml
@@ -1,0 +1,62 @@
+version: '2'
+
+services:
+  mysql:
+    image: sameersbn/mysql:latest
+    environment:
+    - DB_USER=redmine
+    - DB_PASS=password
+    - DB_NAME=redmine_production
+    volumes:
+    - /srv/docker/redmine/mysql:/var/lib/mysql
+
+  redmine:
+    image: sameersbn/redmine:3.4.2
+    depends_on:
+    - mysql
+    environment:
+    - TZ=Asia/Kolkata
+
+    - DB_ADAPTER=mysql2
+    - DB_HOST=mysql
+    - DB_PORT=3306
+    - DB_USER=redmine
+    - DB_PASS=password
+    - DB_NAME=redmine_production
+
+    - REDMINE_PORT=10083
+    - REDMINE_HTTPS=false
+    - REDMINE_RELATIVE_URL_ROOT=
+    - REDMINE_SECRET_TOKEN=
+
+    - REDMINE_SUDO_MODE_ENABLED=false
+    - REDMINE_SUDO_MODE_TIMEOUT=15
+
+    - REDMINE_CONCURRENT_UPLOADS=2
+
+    - REDMINE_BACKUP_SCHEDULE=
+    - REDMINE_BACKUP_EXPIRY=
+    - REDMINE_BACKUP_TIME=
+
+    - SMTP_ENABLED=false
+    - SMTP_METHOD=smtp
+    - SMTP_DOMAIN=www.example.com
+    - SMTP_HOST=smtp.gmail.com
+    - SMTP_PORT=587
+    - SMTP_USER=mailer@example.com
+    - SMTP_PASS=password
+    - SMTP_STARTTLS=true
+    - SMTP_AUTHENTICATION=:login
+
+    - IMAP_ENABLED=false
+    - IMAP_HOST=imap.gmail.com
+    - IMAP_PORT=993
+    - IMAP_USER=mailer@example.com
+    - IMAP_PASS=password
+    - IMAP_SSL=true
+    - IMAP_INTERVAL=30
+
+    ports:
+    - "10083:80"
+    volumes:
+    - /srv/docker/redmine/redmine:/home/redmine/data


### PR DESCRIPTION
Resolving issue #247 

Tested with `docker-compose -f docker-compose-mysql.yml up`

Note that sameersbn/mysql doesn't have any tags available.