### PR TITLE
Fallback to older git version until redmine patches --no-color issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,9 @@ ENV REDMINE_INSTALL_DIR="${REDMINE_HOME}/redmine" \
     REDMINE_BUILD_DIR="${REDMINE_CACHE_DIR}/build" \
     REDMINE_RUNTIME_DIR="${REDMINE_CACHE_DIR}/runtime"
 
+# The latest git version (2.14.1) removes the --no-color option which breaks existing redmine/git
+# support.  We fallback to git 1.9.1 until redmine fixes this. Presumably in redmine 3.4.3
+# Issue #305
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv E1DD270288B4E6030699E45FA1715D88E1DF1F24 \
  && echo "deb http://ppa.launchpad.net/git-core/ppa/ubuntu trusty main" >> /etc/apt/sources.list \
  && apt-key adv --keyserver keyserver.ubuntu.com --recv 80F70E11F0F0D5F10CB20E62F5DA5F09C3173AA6 \
@@ -24,7 +27,7 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv E1DD270288B4E6030699E45F
  && echo 'deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main' > /etc/apt/sources.list.d/pgdg.list \
  && apt-get update \
  && DEBIAN_FRONTEND=noninteractive apt-get install -y supervisor logrotate nginx mysql-client postgresql-client \
-      imagemagick subversion git cvs bzr mercurial darcs rsync ruby${RUBY_VERSION} locales openssh-client \
+      imagemagick subversion git=1:1.9.1-1 git-man=1:1.9.1-1 cvs bzr mercurial darcs rsync ruby${RUBY_VERSION} locales openssh-client \
       gcc g++ make patch pkg-config gettext-base ruby${RUBY_VERSION}-dev libc6-dev zlib1g-dev libxml2-dev \
       libmysqlclient18 libpq5 libyaml-0-2 libcurl3 libssl1.0.0 uuid-dev xz-utils \
       libxslt1.1 libffi6 zlib1g gsfonts \


### PR DESCRIPTION
The latest git version (2.14.1) removes the --no-color option which breaks existing redmine/git
support.  We fallback to git 1.9.1 until redmine fixes this. Presumably in redmine 3.4.3
Issue #305

Unfortunately the ~git-core ppa didn't keep the 2.13.0 version package which didn't have this
issue. So the next available package is 1.9.1 from the standard ubuntu repos.

Fixes #305