### PR TITLE
Fix unicorn startup cause missing libmysqlclient18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ RUN apt-get update \
  && apt-key adv --keyserver keyserver.ubuntu.com --recv 8B3981E7A6852F782CC4951600A6F0A3C300EE8C \
  && echo "deb http://ppa.launchpad.net/nginx/stable/ubuntu xenial main" >> /etc/apt/sources.list \
  && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
- && echo 'deb http://apt.postgresql.org/pub/repos/apt/ xenial-pgdg main' > /etc/apt/sources.list.d/pgdg.list
+ && echo 'deb http://apt.postgresql.org/pub/repos/apt/ xenial-pgdg main' > /etc/apt/sources.list.d/pgdg.list\
+ && wget --quiet http://launchpadlibrarian.net/212189159/libmysqlclient18_5.6.25-0ubuntu1_amd64.deb
 
 FROM ubuntu:xenial-20180705
 
@@ -32,6 +33,8 @@ COPY --from=add-apt-repositories /etc/apt/trusted.gpg /etc/apt/trusted.gpg
 
 COPY --from=add-apt-repositories /etc/apt/sources.list /etc/apt/sources.list
 
+COPY --from=add-apt-repositories libmysqlclient18_5.6.25-0ubuntu1_amd64.deb libmysqlclient18_5.6.25-0ubuntu1_amd64.deb
+
 RUN apt-get update \
  && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
       supervisor logrotate nginx mysql-client postgresql-client ca-certificates sudo tzdata \
@@ -39,6 +42,7 @@ RUN apt-get update \
       gcc g++ make patch pkg-config gettext-base ruby${RUBY_VERSION}-dev libc6-dev zlib1g-dev libxml2-dev \
       libmysqlclient20 libpq5 libyaml-0-2 libcurl3 libssl1.0.0 uuid-dev xz-utils \
       libxslt1.1 libffi6 zlib1g gsfonts \
+ && dpkg -i libmysqlclient18_5.6.25-0ubuntu1_amd64.deb \
  && update-locale LANG=C.UTF-8 LC_MESSAGES=POSIX \
  && gem install --no-document bundler \
  && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
On some host (aws), docker redmine fail cause limysqlclient18 is missing.
Here the log file (unicorn.stderr.log) :

```
/home/redmine/redmine/vendor/bundle/ruby/2.3.0/gems/mysql2-0.4.10/lib/mysql2.rb:31:in `require': libmysqlclient.so.18: cannot open shared object file: No such file or directory - /home/redmine/redmine/vendor/bundle/ruby/2.3.0/gems/mysql2-0.4.10/lib/mysql2/mysql2.so (LoadError)
        from /home/redmine/redmine/vendor/bundle/ruby/2.3.0/gems/mysql2-0.4.10/lib/mysql2.rb:31:in `<top (required)>'
        from /var/lib/gems/2.3.0/gems/bundler-1.16.3/lib/bundler/runtime.rb:81:in `require'
        from /var/lib/gems/2.3.0/gems/bundler-1.16.3/lib/bundler/runtime.rb:81:in `block (2 levels) in require'
        from /var/lib/gems/2.3.0/gems/bundler-1.16.3/lib/bundler/runtime.rb:76:in `each'
        from /var/lib/gems/2.3.0/gems/bundler-1.16.3/lib/bundler/runtime.rb:76:in `block in require'
        from /var/lib/gems/2.3.0/gems/bundler-1.16.3/lib/bundler/runtime.rb:65:in `each'
        from /var/lib/gems/2.3.0/gems/bundler-1.16.3/lib/bundler/runtime.rb:65:in `require'
        from /var/lib/gems/2.3.0/gems/bundler-1.16.3/lib/bundler.rb:114:in `require'
        from /home/redmine/redmine/config/application.rb:5:in `<top (required)>'
        from /home/redmine/redmine/config/environment.rb:2:in `require'
        from /home/redmine/redmine/config/environment.rb:2:in `<top (required)>'
        from config.ru:4:in `require'
        from config.ru:4:in `block in <main>'
        from /home/redmine/redmine/vendor/bundle/ruby/2.3.0/gems/rack-1.6.10/lib/rack/builder.rb:55:in `instance_eval'
        from /home/redmine/redmine/vendor/bundle/ruby/2.3.0/gems/rack-1.6.10/lib/rack/builder.rb:55:in `initialize'
        from config.ru:1:in `new'
        from config.ru:1:in `<main>'
        from /home/redmine/redmine/vendor/bundle/ruby/2.3.0/gems/unicorn-5.4.0/lib/unicorn.rb:56:in `eval'
        from /home/redmine/redmine/vendor/bundle/ruby/2.3.0/gems/unicorn-5.4.0/lib/unicorn.rb:56:in `block in builder'
        from /home/redmine/redmine/vendor/bundle/ruby/2.3.0/gems/unicorn-5.4.0/bin/unicorn_rails:139:in `block in rails_builder'
        from /home/redmine/data/tmp/bundle/ruby/2.3.0/gems/unicorn-5.4.0/lib/unicorn/http_server.rb:795:in `build_app!'
        from /home/redmine/data/tmp/bundle/ruby/2.3.0/gems/unicorn-5.4.0/lib/unicorn/http_server.rb:139:in `start'
        from /home/redmine/redmine/vendor/bundle/ruby/2.3.0/gems/unicorn-5.4.0/bin/unicorn_rails:209:in `<top (required)>'
        from /home/redmine/redmine/vendor/bundle/ruby/2.3.0/bin/unicorn_rails:22:in `load'
        from /home/redmine/redmine/vendor/bundle/ruby/2.3.0/bin/unicorn_rails:22:in `<main>'
```

This fix install libmysqlclient18 from ubuntu archive to solve the issue.
If you want to test the patched image : [https://hub.docker.com/r/superdevofficial/redmine/tags/](https://hub.docker.com/r/superdevofficial/redmine/tags/)