### PR TITLE
Dockerfile: Update ruby to 2.5

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 **4.0.0**
 - redmine: upgrade to v.4.0.0
 - Fix function tmp:sessions:clear
+- Update to ruby 2.5
 
 **3.4.7-1**
 - Fix app:backup:create by installing latest postgresql-client. Issue #364

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ FROM ubuntu:xenial-20180705
 
 LABEL maintainer="sameer@damagehead.com"
 
-ENV RUBY_VERSION=2.3 \
+ENV RUBY_VERSION=2.5 \
     REDMINE_VERSION=4.0.0 \
     REDMINE_USER="redmine" \
     REDMINE_HOME="/home/redmine" \


### PR DESCRIPTION
Ruby 2.3 goes EOL March 2019.  Move to latest supported version for redmine 4.0

Signed-off-by: Cormier, Jonathan <jcormier@criticallink.com>