### PR TITLE
Dockerfile: Update ruby to version 2.4

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 **4.0.0**
 - redmine: upgrade to v.4.0.0
 - Fix function tmp:sessions:clear
+- Update ruby to v2.4
 
 **3.4.7-1**
 - Fix app:backup:create by installing latest postgresql-client. Issue #364

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ FROM ubuntu:xenial-20180705
 
 LABEL maintainer="sameer@damagehead.com"
 
-ENV RUBY_VERSION=2.3 \
+ENV RUBY_VERSION=2.4 \
     REDMINE_VERSION=4.0.0 \
     REDMINE_USER="redmine" \
     REDMINE_HOME="/home/redmine" \


### PR DESCRIPTION
Ruby 2.3 goes EOL March 2019.  Move to next ruby version to keep
compatibility with the most plugins.

Ruby 2.5 broke several plugins. See pull request #376

Ruby version: 2.4.5-p335 (2018-10-18) [x86_64-linux-gnu]