### PR TITLE
Add support for setting Access-Control-Allow-Origin header

### DIFF
--- a/README.md
+++ b/README.md
@@ -614,6 +614,10 @@ Below is the complete list of parameters that can be set using environment varia
 - **NGINX_X_FORWARDED_PROTO**: Advanced configuration option for the `proxy_set_header X-Forwarded-Proto` setting in the redmine nginx vHost configuration. Defaults to `https` when `REDMINE_HTTPS` is `true`, else defaults to `$scheme`.
 - **NGINX_HSTS_ENABLED**: Advanced configuration option for turning off the HSTS configuration. Applicable only when SSL is in use. Defaults to `true`. See [#138](https://github.com/sameersbn/docker-gitlab/issues/138) for use case scenario.
 - **NGINX_HSTS_MAXAGE**: Advanced configuration option for setting the HSTS max-age in the redmine nginx vHost configuration. Applicable only when SSL is in use. Defaults to `31536000`.
+- **NGINX_CORS_ALLOW_ORIGIN**: Sets `Access-Control-Allow-Origin` response header to indicate that the response can be shared with requesting code from the given origin.
+- **NGINX_CORS_ALLOW_METHODS**: Sets `Access-Control-Allow-Methods` response header to specify the methods allowed when accessing the resource in response to a preflight request.
+- **NGINX_CORS_ALLOW_HEADERS**: Sets `Access-Control-Allow-Headers` response header to specify which headers can be used during the actual request.
+- **NGINX_CORS_ALLOW_CREDENTIALS**: Sets `Access-Control-Allow-Credentials` response header to tell browsers whether to expose the response to frontend JavaScript code when the request's credentials mode (Request.credentials) is include.
 - **UNICORN_WORKERS**: The number of unicorn workers to start. Defaults to `2`.
 - **UNICORN_TIMEOUT**: Sets the timeout of unicorn worker processes. Defaults to `60` seconds.
 - **MEMCACHE_HOST**: The host name of the memcached server. No defaults.

--- a/assets/runtime/config/nginx/redmine
+++ b/assets/runtime/config/nginx/redmine
@@ -27,6 +27,14 @@ server {
     try_files $file @redmine;
   }
 
+  add_header Access-Control-Allow-Origin '{{NGINX_CORS_ALLOW_ORIGIN}}';
+  add_header Access-Control-Allow-Methods '{{NGINX_CORS_ALLOW_METHODS}}';
+  add_header Access-Control-Allow-Headers '{{NGINX_CORS_ALLOW_HEADERS}}';
+  add_header Access-Control-Allow-Credentials '{{NGINX_CORS_ALLOW_CREDENTIALS}}';
+  if ($request_method = 'OPTIONS' ) {
+    return 204 no-content;
+  }
+
   ## If a file, which is not found in the root folder is requested,
   ## then the proxy passes the request to the upsteam (redmine unicorn).
   location @redmine {

--- a/assets/runtime/config/nginx/redmine-ssl
+++ b/assets/runtime/config/nginx/redmine-ssl
@@ -11,7 +11,7 @@ server {
   listen [::]:80 default_server;
   server_name _;
   server_tokens off;
-  
+
   ## Redirects all traffic to the HTTPS host
   return 301 https://$host:{{REDMINE_PORT}}$request_uri;
 }
@@ -74,6 +74,14 @@ server {
     ## Serve static files from defined root folder.
     ## @redmine is a named location for the upstream fallback, see below.
     try_files $file @redmine;
+  }
+
+  add_header Access-Control-Allow-Origin '{{NGINX_CORS_ALLOW_ORIGIN}}';
+  add_header Access-Control-Allow-Methods '{{NGINX_CORS_ALLOW_METHODS}}';
+  add_header Access-Control-Allow-Headers '{{NGINX_CORS_ALLOW_HEADERS}}';
+  add_header Access-Control-Allow-Credentials '{{NGINX_CORS_ALLOW_CREDENTIALS}}';
+  if ($request_method = 'OPTIONS' ) {
+    return 204 no-content;
   }
 
   ## If a file, which is not found in the root folder is requested,

--- a/assets/runtime/functions
+++ b/assets/runtime/functions
@@ -869,7 +869,11 @@ nginx_configure_redmine() {
     REDMINE_LOG_DIR \
     REDMINE_PORT \
     NGINX_MAX_UPLOAD_SIZE \
-    NGINX_X_FORWARDED_PROTO
+    NGINX_X_FORWARDED_PROTO \
+    NGINX_CORS_ALLOW_ORIGIN \
+    NGINX_CORS_ALLOW_METHODS \
+    NGINX_CORS_ALLOW_HEADERS \
+    NGINX_CORS_ALLOW_CREDENTIALS
 
   nginx_configure_redmine_ssl
   nginx_configure_redmine_hsts


### PR DESCRIPTION
This PR adds support for setting `Access-Control-Allow-Origin` header, see #147