### PR TITLE
Install ghostscript to enable optional PDF support.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN apt-get update \
       imagemagick subversion git cvs bzr mercurial darcs rsync ruby${RUBY_VERSION} locales openssh-client \
       gcc g++ make patch pkg-config gettext-base ruby${RUBY_VERSION}-dev libc6-dev zlib1g-dev libxml2-dev \
       libmysqlclient20 libpq5 libyaml-0-2 libcurl3 libssl1.0.0 uuid-dev xz-utils \
-      libxslt1.1 libffi6 zlib1g gsfonts vim-tiny \
+      libxslt1.1 libffi6 zlib1g gsfonts vim-tiny ghostscript \
  && update-locale LANG=C.UTF-8 LC_MESSAGES=POSIX \
  && gem install --no-document bundler \
  && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Currently docker image has no /usr/bin/gs, so "ImageMagick PDF support available (optional)" is unavailable.

This patch just installs ghostscript to enable the option.