### PR TITLE
Update ImageMagick policy to allow PDF read for thumbnail generation.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,8 +42,7 @@ RUN apt-get update \
       libxslt1.1 libffi6 zlib1g gsfonts vim-tiny ghostscript \
  && update-locale LANG=C.UTF-8 LC_MESSAGES=POSIX \
  && gem install --no-document bundler \
- && rm -rf /var/lib/apt/lists/* \
- && sed -i 's/ domain="coder" rights="none" pattern="PDF" / domain="coder" rights="read" pattern="PDF" /g' /etc/ImageMagick-*/policy.xml
+ && rm -rf /var/lib/apt/lists/*
 
 COPY assets/build/ ${REDMINE_BUILD_ASSETS_DIR}/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,8 @@ RUN apt-get update \
       libxslt1.1 libffi6 zlib1g gsfonts vim-tiny ghostscript \
  && update-locale LANG=C.UTF-8 LC_MESSAGES=POSIX \
  && gem install --no-document bundler \
- && rm -rf /var/lib/apt/lists/*
+ && rm -rf /var/lib/apt/lists/* \
+ && sed -i 's/ domain="coder" rights="none" pattern="PDF" / domain="coder" rights="read" pattern="PDF" /g' /etc/ImageMagick-*/policy.xml
 
 COPY assets/build/ ${REDMINE_BUILD_ASSETS_DIR}/
 

--- a/assets/build/install.sh
+++ b/assets/build/install.sh
@@ -200,6 +200,10 @@ EOF
 sed -i '/\.sock/a password=dummy' /etc/supervisor/supervisord.conf
 sed -i '/\.sock/a username=dummy' /etc/supervisor/supervisord.conf
 
+# update ImageMagick policy to allow PDF read for thumbnail generation.
+# https://github.com/sameersbn/docker-redmine/pull/421
+sed -i 's/ domain="coder" rights="none" pattern="PDF" / domain="coder" rights="read" pattern="PDF" /g' /etc/ImageMagick-*/policy.xml
+
 # purge build dependencies and cleanup apt
 apt-get purge -y --auto-remove ${BUILD_DEPENDENCIES}
 rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Thank you for merging #420!

However, I found PDF thumbnail generation is still not worked due to Ubuntu default setting you used as base image.

I add a simple sed one-liner to allow image magick to process PDF files...