### PR TITLE
fix saving image version

### DIFF
--- a/assets/runtime/functions
+++ b/assets/runtime/functions
@@ -963,7 +963,7 @@ version_check() {
   rm -rf "${REDMINE_INSTALL_DIR}/vendor/bundle" "${REDMINE_INSTALL_DIR}/Gemfile.lock"
 
   # Track docker image version in tmp cache
-  echo "${CACHE_IMAGE_VERSION}" > "${REDMINE_DATA_DIR}/tmp/IMAGE_VERSION"
+  echo "${IMAGE_VERSION}" > "${REDMINE_DATA_DIR}/tmp/IMAGE_VERSION"
 
   # symlink to ${REDMINE_DATA_DIR}/tmp/bundle
   ln -sf "${REDMINE_DATA_DIR}/tmp/bundle" "${REDMINE_INSTALL_DIR}/vendor/bundle"


### PR DESCRIPTION
The version of the image was not saved, when the container was stopped and started, tmp directory was deleted and there was nowhere to copy the vendor/bundle folder to tmp.