### PR TITLE
Add REDMINE_RMAGICK_FONT_PATH parameter for Redmine 4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -587,6 +587,7 @@ Below is the complete list of parameters that can be set using environment varia
 - **REDMINE_RELATIVE_URL_ROOT**: The relative url of the Redmine server, e.g. `/redmine`. No default.
 - **REDMINE_ATTACHMENTS_DIR**: The attachments directory. Defaults to `/home/redmine/data/files`
 - **REDMINE_SECRET_TOKEN**: Secret key for verifying cookie session data integrity. Defaults to a random alphanumeric string.
+- **REDMINE_RMAGICK_FONT_PATH**: The rmagick_font_path for the png export function of GANTT to work. Defaults to `DejaVuSans.tff`.
 - **REDMINE_CONCURRENT_UPLOADS**: Maximum number of simultaneous AJAX uploads. Defaults to `2`.
 - **REDMINE_SUDO_MODE_ENABLED**: Requires users to re-enter their password for sensitive actions. Defaults to `false`.
 - **REDMINE_SUDO_MODE_TIMEOUT**: Sudo mode timeout. Defaults to `15` minutes.

--- a/assets/runtime/config/redmine/configuration.yml
+++ b/assets/runtime/config/redmine/configuration.yml
@@ -132,7 +132,7 @@ default:
   # you need to set a font installed in your server.
   #
   # This setting is not necessary in non CJK.
-  # rmagick_font_path:
+  rmagick_font_path: {{READMINE_RMAGICK_FONT_PATH}}
 
   # Maximum number of simultaneous AJAX uploads
   max_concurrent_ajax_uploads: {{REDMINE_CONCURRENT_UPLOADS}}

--- a/assets/runtime/config/redmine/configuration.yml
+++ b/assets/runtime/config/redmine/configuration.yml
@@ -132,7 +132,7 @@ default:
   # you need to set a font installed in your server.
   #
   # This setting is not necessary in non CJK.
-  rmagick_font_path: {{READMINE_RMAGICK_FONT_PATH}}
+  rmagick_font_path: {{REDMINE_RMAGICK_FONT_PATH}}
 
   # Maximum number of simultaneous AJAX uploads
   max_concurrent_ajax_uploads: {{REDMINE_CONCURRENT_UPLOADS}}

--- a/assets/runtime/env-defaults
+++ b/assets/runtime/env-defaults
@@ -134,3 +134,6 @@ if [[ $REDMINE_HTTPS == true ]]; then
 else
   NGINX_X_FORWARDED_PROTO=${NGINX_X_FORWARDED_PROTO:-\$scheme}
 fi
+
+## RMAGICK
+REDMINE_RMAGICK_FONT_PATH=${REDMINE_RMAGICK_FONT_PATH:-/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf}

--- a/assets/runtime/functions
+++ b/assets/runtime/functions
@@ -483,6 +483,12 @@ redmine_configure_backups() {
   redmine_configure_backups_schedule
 }
 
+redmine_configure_rmagick_font() {
+  echo "Configuring redmine::rmagic::font..."
+  update_template ${REDMINE_CONFIG} \
+    REDMINE_RMAGICK_FONT_PATH
+}
+
 backup_dump_database() {
   eval $(parse_yaml ${REDMINE_CONFIG} config_)
   eval $(parse_yaml ${REDMINE_DATABASE_CONFIG} database_)
@@ -804,6 +810,7 @@ configure_redmine() {
   redmine_configure_incoming_email
   redmine_configure_fetch_commits
   redmine_configure_backups
+  redmine_configure_rmagick_font
 
   # configure secure-cookie if using SSL/TLS
   if [[ ${REDMINE_HTTPS} == true ]]; then


### PR DESCRIPTION
I would like to propose adding the `REDMINE_RMAGICK_FONT_PATH` parameter to set `rmagick_font_path`.

ref. #439
