### PR TITLE
Dockerfile: Update ruby to 2.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ FROM ubuntu:xenial-20190222
 
 LABEL maintainer="sameer@damagehead.com"
 
-ENV RUBY_VERSION=2.4 \
+ENV RUBY_VERSION=2.6 \
     REDMINE_VERSION=4.1.1 \
     REDMINE_USER="redmine" \
     REDMINE_HOME="/home/redmine" \


### PR DESCRIPTION
Ruby 2.4 is already EOL, and 2.5 will be EOL at 2021-03-31.
Previously plugin issue #376 was blockage of updating to 2.5.
Does this still exist?
Even if so, I think updating to 2.6 is better.