### PR TITLE
Fixed mysql-client version to 5.7.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,9 @@ RUN apt-get update \
  && apt-key adv --keyserver keyserver.ubuntu.com --recv 8B3981E7A6852F782CC4951600A6F0A3C300EE8C \
  && echo "deb http://ppa.launchpad.net/nginx/stable/ubuntu focal main" >> /etc/apt/sources.list \
  && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
- && echo 'deb http://apt.postgresql.org/pub/repos/apt/ focal-pgdg main' > /etc/apt/sources.list.d/pgdg.list
+ && echo 'deb http://apt.postgresql.org/pub/repos/apt/ focal-pgdg main' > /etc/apt/sources.list.d/pgdg.list \
+ && apt-key adv --keyserver keys.gnupg.net --recv 8C718D3B5072E1F5 \
+ && echo "deb http://repo.mysql.com/apt/ubuntu/ bionic mysql-5.7" >> /etc/apt/sources.list
 
 FROM ubuntu:focal-20210217
 
@@ -35,7 +37,7 @@ COPY --from=add-apt-repositories /etc/apt/sources.list.d/pgdg.list /etc/apt/sour
 
 RUN apt-get update \
  && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
-      supervisor logrotate nginx mysql-client postgresql-client ca-certificates sudo tzdata \
+      supervisor logrotate nginx mysql-client=5.7.* postgresql-client ca-certificates sudo tzdata \
       imagemagick subversion git cvs bzr mercurial darcs rsync ruby${RUBY_VERSION} locales openssh-client \
       gcc g++ make patch pkg-config gettext-base ruby${RUBY_VERSION}-dev libc6-dev zlib1g-dev libxml2-dev \
       libmysqlclient21 libpq5 libyaml-0-2 libcurl4 libssl1.1 uuid-dev xz-utils \


### PR DESCRIPTION
as is
---
When I try to make a backup while using mysql for DB, it fails,
```bash
docker-compose -f docker-compose-mysql.yml run --rm redmine app:backup:create
```

> Initializing logdir...
> Initializing datadir...
> Symlinking dotfiles...
> Installing configuration templates...
> Configuring redmine...
> Configuring redmine::database
> Configuring redmine::unicorn...
> Configuring redmine::secret_token...
> Generating a session token...
> Note:
>   All old sessions will become invalid.
>   Please specify the REDMINE_SECRET_TOKEN parameter for persistence.
>   **SHOULD** be defined if you have a load-balancing Redmine cluster.
> Configuring redmine::max_concurrent_ajax_uploads...
> Configuring redmine::sudo_mode...
> Configuring redmine::autologin_cookie...
> Configuring redmine::backups...
> Configuring redmine::rmagic::font...
> Configuring nginx...
> Configuring nginx::redmine...
> Dumping MySQL database redmine_production...
> mysqldump: Couldn't execute 'SELECT COLUMN_NAME,                       JSON_EXTRACT(HISTOGRAM, '$."number-of-buckets-specified"')                FROM information_schema.COLUMN_STATISTICS                WHERE SCHEMA_NAME = 'redmine_production' AND TABLE_NAME = 'ar_internal_metadata';': Unknown table 'COLUMN_STATISTICS' in information_schema (1109)

to be
---
The backup ends normally.

cause
---
The version of mysql-client has changed from Ubuntu focal to 8. On the other hand, the supported version of mysql in Redmine is 5.5 to 5.7. [1]
If you do not suppress column-statistics to use version 8 mysqldump for version 5.7 or earlier mysql, you will get an error.

suggestion
---
There seems to be no merit to raise the version of mysql-client, so why not fix it to version 5.7?

[1]: https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Supported-database-back-ends