### PR TITLE
Fix keyserver issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:focal-20210217 AS add-apt-repositories
+FROM ubuntu:focal-20210609 AS add-apt-repositories
 
 RUN apt-get update \
  && DEBIAN_FRONTEND=noninteractive apt-get install -y wget gnupg2 \
@@ -13,7 +13,7 @@ RUN apt-get update \
  && apt-key adv --keyserver keyserver.ubuntu.com --recv 8C718D3B5072E1F5 \
  && echo "deb http://repo.mysql.com/apt/ubuntu/ bionic mysql-5.7" >> /etc/apt/sources.list
 
-FROM ubuntu:focal-20210217
+FROM ubuntu:focal-20210609
 
 LABEL maintainer="sameer@damagehead.com"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update \
  && echo "deb http://ppa.launchpad.net/nginx/stable/ubuntu focal main" >> /etc/apt/sources.list \
  && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
  && echo 'deb http://apt.postgresql.org/pub/repos/apt/ focal-pgdg main' > /etc/apt/sources.list.d/pgdg.list \
- && apt-key adv --keyserver keys.gnupg.net --recv 8C718D3B5072E1F5 \
+ && apt-key adv --keyserver keyserver.ubuntu.com --recv 8C718D3B5072E1F5 \
  && echo "deb http://repo.mysql.com/apt/ubuntu/ bionic mysql-5.7" >> /etc/apt/sources.list
 
 FROM ubuntu:focal-20210217


### PR DESCRIPTION
When rebuilding the Docker image, I received the following error message:

```
Warning: apt-key output should not be parsed (stdout is not a terminal)
Executing: /tmp/apt-key-gpghome.yOGvv4HtFV/gpg.1.sh --keyserver keys.gnupg.net --recv 8C718D3B5072E1F5
gpg: keyserver receive failed: No name
```

After a short research it came to my attention that server `keys.gnupg.net` is just an alias for the server pool `pool.sks-keyservers.net` (see <https://stackoverflow.com/questions/44768657/cannot-add-keys-from-keys-gnupg-net>).

Via the web page <https://sks-keyservers.net/> I learned that apparently the underlying service is deprecated. To be more precise, at the site it is stated that 

> This service is deprecated. This means it is no longer maintained, and new HKPS certificates will not be issued. Service reliability should not be expected.
> 
> Update 2021-06-21: Due to even more GDPR takedown requests, the DNS records for the pool will no longer be provided at all.

.

One solution to the problem is to use keyserver `keyserver.ubuntu.com`, which I use instead of keyserver `keys.gnupg.net` to build the image. And eventually, after this change, building the image is successful again. (At this opportunity I renewed the used base image as well.)