### PR TITLE
Fixed "undefined method dup_value" in setting page

### DIFF
--- a/assets/runtime/config/redmine/additional_environment.rb
+++ b/assets/runtime/config/redmine/additional_environment.rb
@@ -1,4 +1,4 @@
 config.gem 'dalli'
 config.action_controller.perform_caching  = true
 config.cache_classes = true
-config.cache_store = :dalli_store, "{{MEMCACHE_HOST}}:{{MEMCACHE_PORT}}"
+config.cache_store = :mem_cache_store, "{{MEMCACHE_HOST}}:{{MEMCACHE_PORT}}"


### PR DESCRIPTION
as is
---
I'm using Redmine with memcached.
An "Internal error" occurred when navigating to the personal or administrative settings page.

The production.log is as follows:
```
I, [2022-04-16T19:33:18.204370 #297]  INFO -- : [10c706a8-acad-4766-9321-6152074cdea9] Started GET "/redmine/settings" for 192.168.11.16 at 2022-04-16 19:33:18 +0900
I, [2022-04-16T19:33:18.205237 #297]  INFO -- : [10c706a8-acad-4766-9321-6152074cdea9] Processing by SettingsController#index as HTML
I, [2022-04-16T19:33:18.209929 #297]  INFO -- : [10c706a8-acad-4766-9321-6152074cdea9]   Current user: K0GiHF9S (id=5)
I, [2022-04-16T19:33:18.246472 #297]  INFO -- : [10c706a8-acad-4766-9321-6152074cdea9]   Rendered settings/edit.html.erb within layouts/admin (Duration: 32.6ms | Allocations: 10424)
I, [2022-04-16T19:33:18.246583 #297]  INFO -- : [10c706a8-acad-4766-9321-6152074cdea9]   Rendered layout layouts/admin.html.erb (Duration: 32.7ms | Allocations: 10452)
I, [2022-04-16T19:33:18.246893 #297]  INFO -- : [10c706a8-acad-4766-9321-6152074cdea9] Completed 500 Internal Server Error in 42ms (ActiveRecord: 6.2ms | Allocations: 12959)
F, [2022-04-16T19:33:18.248213 #297] FATAL -- : [10c706a8-acad-4766-9321-6152074cdea9]   
[10c706a8-acad-4766-9321-6152074cdea9] ActionView::Template::Error (undefined method `dup_value!' for #<Array:0x000056035269ab80>):
[10c706a8-acad-4766-9321-6152074cdea9]     3: <div class="box tabular settings">
[10c706a8-acad-4766-9321-6152074cdea9]     4: <p><%= setting_select :ui_theme, Redmine::Themes.themes.collect {|t| [t.name, t.id]}, :blank => :label_default, :label => :label_theme %></p>
[10c706a8-acad-4766-9321-6152074cdea9]     5: 
[10c706a8-acad-4766-9321-6152074cdea9]     6: <p><%= setting_select :default_language, lang_options_for_select(false) %></p>
[10c706a8-acad-4766-9321-6152074cdea9]     7: 
[10c706a8-acad-4766-9321-6152074cdea9]     8: <p><%= setting_check_box :force_default_language_for_anonymous %></p>
[10c706a8-acad-4766-9321-6152074cdea9]     9: 
[10c706a8-acad-4766-9321-6152074cdea9]   
[10c706a8-acad-4766-9321-6152074cdea9] lib/redmine/i18n.rb:132:in `languages_options'
[10c706a8-acad-4766-9321-6152074cdea9] app/helpers/application_helper.rb:1468:in `lang_options_for_select'
[10c706a8-acad-4766-9321-6152074cdea9] app/views/settings/_display.html.erb:6
[10c706a8-acad-4766-9321-6152074cdea9] app/views/settings/_display.html.erb:1
[10c706a8-acad-4766-9321-6152074cdea9] app/views/common/_tabs.html.erb:21
[10c706a8-acad-4766-9321-6152074cdea9] app/views/common/_tabs.html.erb:20:in `each'
[10c706a8-acad-4766-9321-6152074cdea9] app/views/common/_tabs.html.erb:20
[10c706a8-acad-4766-9321-6152074cdea9] app/helpers/application_helper.rb:496:in `render_tabs'
[10c706a8-acad-4766-9321-6152074cdea9] app/views/settings/edit.html.erb:5
[10c706a8-acad-4766-9321-6152074cdea9] app/controllers/settings_controller.rb:33:in `index'
[10c706a8-acad-4766-9321-6152074cdea9] lib/redmine/sudo_mode.rb:61:in `sudo_mode'
```

to be
---
The setting page can be displayed correctly.

cause
---
This is because `:dalli_store` is not available in rails 6.1.
Similar issues have been reported: petergoldstein/dalli#771

suggestion
---
Replace `dalli_store` with `mem_cache_store`.
