### PR TITLE
add healthcheck and depends_on condition to docker-compose.yml.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,12 +9,18 @@ services:
       - DB_NAME=redmine_production
     volumes:
       - /srv/docker/redmine/postgresql:/var/lib/postgresql
-
+    healthcheck:
+      test: "psql -U postgres"
+      interval: 3s
+      timeout: 3s
+      retries: 5
+      start_period: 10s
   redmine:
     build: ./
     image: sameersbn/redmine:5.0.5
     depends_on:
-      - postgresql
+      postgresql:
+        condition: service_healthy
     environment:
       - TZ=Asia/Kolkata
 


### PR DESCRIPTION
Confilm log and working normally


```
[+] Running 2/2
 ✔ Container docker-redmine-postgresql-1  Recreated                                                                0.1s
 ✔ Container docker-redmine-redmine-1     Recreated                                                                0.1s
Attaching to docker-redmine-postgresql-1, docker-redmine-redmine-1
docker-redmine-postgresql-1  | Initializing datadir...
docker-redmine-postgresql-1  | Initializing certdir...
docker-redmine-postgresql-1  | Initializing logdir...
docker-redmine-postgresql-1  | Initializing rundir...
docker-redmine-postgresql-1  | Setting resolv.conf ACLs...
docker-redmine-postgresql-1  | Creating database user: redmine
docker-redmine-postgresql-1  | Creating database: redmine_production...
docker-redmine-postgresql-1  | ‣ Granting access to redmine user...
docker-redmine-postgresql-1  | Starting PostgreSQL 9.6...
docker-redmine-postgresql-1  | LOG:  database system was shut down at 2023-05-23 01:47:16 UTC
docker-redmine-postgresql-1  | LOG:  MultiXact member wraparound protections are now enabled
docker-redmine-postgresql-1  | LOG:  autovacuum launcher started
docker-redmine-postgresql-1  | LOG:  database system is ready to accept connections
docker-redmine-redmine-1     | Initializing logdir...
docker-redmine-redmine-1     | Initializing datadir...
docker-redmine-redmine-1     | Symlinking dotfiles...
docker-redmine-redmine-1     | Installing configuration templates...
docker-redmine-redmine-1     | Configuring redmine...
docker-redmine-redmine-1     | Configuring redmine::database
docker-redmine-redmine-1     | Configuring redmine::unicorn...
docker-redmine-redmine-1     | Configuring redmine::secret_token...
docker-redmine-redmine-1     | Generating a session token...
docker-redmine-redmine-1     | Note:
docker-redmine-redmine-1     |   All old sessions will become invalid.
docker-redmine-redmine-1     |   Please specify the REDMINE_SECRET_TOKEN parameter for persistence.
docker-redmine-redmine-1     |   **SHOULD** be defined if you have a load-balancing Redmine cluster.
docker-redmine-redmine-1     | Configuring redmine::max_concurrent_ajax_uploads...
docker-redmine-redmine-1     | Configuring redmine::sudo_mode...
docker-redmine-redmine-1     | Configuring redmine::autologin_cookie...
docker-redmine-redmine-1     | Configuring redmine::backups...
docker-redmine-redmine-1     | Configuring redmine::rmagic::font...
docker-redmine-redmine-1     | Configuring nginx...
docker-redmine-redmine-1     | Configuring nginx::redmine...
docker-redmine-redmine-1     | Installing plugins...
docker-redmine-redmine-1     | Installing themes...
docker-redmine-redmine-1     | 2023-05-23 07:17:19,406 INFO Included extra file "/etc/supervisor/conf.d/cron.conf" during parsing
docker-redmine-redmine-1     | 2023-05-23 07:17:19,406 INFO Included extra file "/etc/supervisor/conf.d/nginx.conf" during parsing
docker-redmine-redmine-1     | 2023-05-23 07:17:19,406 INFO Included extra file "/etc/supervisor/conf.d/unicorn.conf" during parsing
docker-redmine-redmine-1     | 2023-05-23 07:17:19,406 INFO Set uid to user 0 succeeded
docker-redmine-redmine-1     | 2023-05-23 07:17:19,409 INFO RPC interface 'supervisor' initialized
docker-redmine-redmine-1     | 2023-05-23 07:17:19,409 INFO supervisord started with pid 1
docker-redmine-redmine-1     | 2023-05-23 07:17:20,414 INFO spawned: 'unicorn' with pid 250
docker-redmine-redmine-1     | 2023-05-23 07:17:20,418 INFO spawned: 'cron' with pid 251
docker-redmine-redmine-1     | 2023-05-23 07:17:20,422 INFO spawned: 'nginx' with pid 252
docker-redmine-redmine-1     | 2023-05-23 07:17:21,729 INFO success: unicorn entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
docker-redmine-redmine-1     | 2023-05-23 07:17:21,730 INFO success: cron entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
docker-redmine-redmine-1     | 2023-05-23 07:17:21,730 INFO success: nginx entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
```