### PR TITLE
Support DATABASE_URL

### DIFF
--- a/assets/runtime/functions
+++ b/assets/runtime/functions
@@ -149,6 +149,23 @@ redmine_finalize_database_parameters() {
     DB_USER=${DB_USER:-${POSTGRESQL_ENV_USER}}
     DB_PASS=${DB_PASS:-${POSTGRESQL_ENV_PASS}}
     DB_NAME=${DB_NAME:-${POSTGRESQL_ENV_DB}}
+  elif [[ -n ${DATABASE_URL} ]]; then
+    case $(ruby -r uri -e 'puts URI(ENV["DATABASE_URL"]).scheme') in
+      postgres*)
+        DB_ADAPTER=${DB_ADAPTER:-postgresql}
+        DB_HOST=${DB_HOST:-$(ruby -r uri -e 'puts URI(ENV["DATABASE_URL"]).hostname')}
+        DB_USER=${DB_USER:-$(ruby -r uri -e 'puts URI(ENV["DATABASE_URL"]).user')}
+        DB_PASS=${DB_PASS:-$(ruby -r uri -e 'puts URI(ENV["DATABASE_URL"]).password')}
+        DB_NAME=${DB_NAME:-$(ruby -r uri -e 'puts URI(ENV["DATABASE_URL"]).path.delete_prefix("/")')}
+        ;;
+      mysql*)
+        DB_ADAPTER=${DB_ADAPTER:-mysql2}
+        DB_HOST=${DB_HOST:-$(ruby -r uri -e 'puts URI(ENV["DATABASE_URL"]).hostname')}
+        DB_USER=${DB_USER:-$(ruby -r uri -e 'puts URI(ENV["DATABASE_URL"]).user')}
+        DB_PASS=${DB_PASS:-$(ruby -r uri -e 'puts URI(ENV["DATABASE_URL"]).password')}
+        DB_NAME=${DB_NAME:-$(ruby -r uri -e 'puts URI(ENV["DATABASE_URL"]).path.delete_prefix("/")')}
+        ;;
+    esac
   fi
 
   if [[ "${DB_ADAPTER}" == sqlite3 ]]; then


### PR DESCRIPTION
Use `DATABASE_URL` only if `DB_*` are unset for backward compatibility.

## background

I use this docker image on [Dokku](https://dokku.com/) with [dokku-postgres](https://github.com/dokku/dokku-postgres).
It sets `DATABASE_URL` and `DOKKU_POSTGRES_{SERVICE_NAME}_PORT_5432_TCP*`.

So I set `DB_ADAPTER=postgresql` and `DB_HOST={SERVICE_NAME}` manually. (because of `redmine_check_database_connection` minimum requirements)
And I set `DB_HOST={NEW_SERVICE_NAME}` again after I upgrade database services with creating and promoting.
I often forgot to set `DB_HOST` again, and `redmine` failed after unlinking old service.

So I want this docker image to use `DATABASE_URL` if set.