### PR TITLE
Update supporting DATABASE_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -619,6 +619,7 @@ Below is the complete list of parameters that can be set using environment varia
 - **REDMINE_BACKUP_SCHEDULE**: Setup cron job to schedule automatic backups. Possible values `disable`, `daily`, `weekly` or `monthly`. Disabled by default
 - **REDMINE_BACKUP_EXPIRY**: Configure how long (in seconds) to keep backups before they are deleted. By default when automated backups are disabled backups are kept forever (0 seconds), else the backups expire in 7 days (604800 seconds).
 - **REDMINE_BACKUP_TIME**: Set a time for the automatic backups in `HH:MM` format. Defaults to `04:00`.
+- **DATABASE_URL**: The database URL. See [Configuring a Database](https://guides.rubyonrails.org/configuring.html#configuring-a-database). Possible schemes: `postgres`, `postgresql`, `mysql2`, and `sqlite3`. Defaults to no URL.
 - **DB_ADAPTER**: The database type. Possible values: `mysql2`, `postgresql`, and 'sqlite3'. Defaults to `mysql`.
 - **DB_ENCODING**: The database encoding. For `DB_ADAPTER` values `postresql` and `mysql2`, this parameter defaults to `unicode` and `utf8` respectively.
 - **DB_HOST**: The database server hostname. Defaults to `localhost`.

--- a/assets/runtime/functions
+++ b/assets/runtime/functions
@@ -150,20 +150,23 @@ redmine_finalize_database_parameters() {
     DB_PASS=${DB_PASS:-${POSTGRESQL_ENV_PASS}}
     DB_NAME=${DB_NAME:-${POSTGRESQL_ENV_DB}}
   elif [[ -n ${DATABASE_URL} ]]; then
+    # Set environments for redmine_check_database_connection
     case $(ruby -r uri -e 'puts URI(ENV["DATABASE_URL"]).scheme') in
-      postgres*)
+      postgres | postgresql)
         DB_ADAPTER=${DB_ADAPTER:-postgresql}
         DB_HOST=${DB_HOST:-$(ruby -r uri -e 'puts URI(ENV["DATABASE_URL"]).hostname')}
+        DB_PORT=${DB_PORT:-$(ruby -r uri -e 'puts URI(ENV["DATABASE_URL"]).port || 5432')}
         DB_USER=${DB_USER:-$(ruby -r uri -e 'puts URI(ENV["DATABASE_URL"]).user')}
-        DB_PASS=${DB_PASS:-$(ruby -r uri -e 'puts URI(ENV["DATABASE_URL"]).password')}
-        DB_NAME=${DB_NAME:-$(ruby -r uri -e 'puts URI(ENV["DATABASE_URL"]).path.delete_prefix("/")')}
         ;;
-      mysql*)
+      mysql2)
         DB_ADAPTER=${DB_ADAPTER:-mysql2}
         DB_HOST=${DB_HOST:-$(ruby -r uri -e 'puts URI(ENV["DATABASE_URL"]).hostname')}
+        DB_PORT=${DB_PORT:-$(ruby -r uri -e 'puts URI(ENV["DATABASE_URL"]).port || 3306')}
         DB_USER=${DB_USER:-$(ruby -r uri -e 'puts URI(ENV["DATABASE_URL"]).user')}
         DB_PASS=${DB_PASS:-$(ruby -r uri -e 'puts URI(ENV["DATABASE_URL"]).password')}
-        DB_NAME=${DB_NAME:-$(ruby -r uri -e 'puts URI(ENV["DATABASE_URL"]).path.delete_prefix("/")')}
+        ;;
+      sqlite3)
+        DB_ADAPTER=${DB_ADAPTER:-sqlite3}
         ;;
     esac
   fi


### PR DESCRIPTION
Sorry for my late response.
This is follow up pull request of <https://github.com/sameersbn/docker-redmine/pull/516>.

I updated README, and environments.

Remove some environments which do not used by `redmine_check_database_connection`, and use `DB_PORT` from `DATABASE_URL`. And support `sqlite3`.

`DATABASE_URL` does not have official document.
In rails, `DATABASE_URL` is used in <https://github.com/rails/rails/blob/5694f1ec0305e1946f6505257c596d4d6be9c4e4/activerecord/lib/active_record/database_configurations/connection_url_resolver.rb>.