### PR TITLE
README: mention utf8mb4 for full unicode support

### DIFF
--- a/README.md
+++ b/README.md
@@ -621,7 +621,7 @@ Below is the complete list of parameters that can be set using environment varia
 - **REDMINE_BACKUP_TIME**: Set a time for the automatic backups in `HH:MM` format. Defaults to `04:00`.
 - **DATABASE_URL**: The database URL. See [Configuring a Database](https://guides.rubyonrails.org/configuring.html#configuring-a-database). Possible schemes: `postgres`, `postgresql`, `mysql2`, and `sqlite3`. Defaults to no URL.
 - **DB_ADAPTER**: The database type. Possible values: `mysql2`, `postgresql`, and 'sqlite3'. Defaults to `mysql`.
-- **DB_ENCODING**: The database encoding. For `DB_ADAPTER` values `postresql` and `mysql2`, this parameter defaults to `unicode` and `utf8` respectively.
+- **DB_ENCODING**: The database encoding. For `DB_ADAPTER` values `postresql` and `mysql2`, this parameter defaults to `unicode` and `utf8` respectively. For full unicode support (all emojis) with mariadb or mysql set this to `utf8mb4` and make sure to also set all tables to `utf8mb4` and use `collate utf8mb4_unicode_ci`. Existing databases can be converted by following this [HowTo](https://www.redmine.org/projects/redmine/wiki/HowTo_convert_a_database_from_utf8_to_utf8mb4).
 - **DB_HOST**: The database server hostname. Defaults to `localhost`.
 - **DB_PORT**: The database server port. Defaults to `3306`.
 - **DB_NAME**: The database name. Defaults to `redmine_production`

--- a/docker-compose-mariadb.yml
+++ b/docker-compose-mariadb.yml
@@ -12,7 +12,13 @@ services:
     volumes:
       - /srv/docker/redmine/mariadb:/var/lib/mysql
     # https://www.redmine.org/projects/redmine/wiki/MySQL_configuration
-    command: mariadbd --transaction-isolation=READ-COMMITTED
+    command:
+      - mariadbd
+      # https://www.redmine.org/projects/redmine/wiki/MySQL_configuration
+      - --transaction-isolation=READ-COMMITTED
+      # Configure 4byte utf8 support for full unicode support (all emojis), this requires manual conversion for existing tables. See README
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
 
   redmine:
     build: ./
@@ -23,6 +29,7 @@ services:
       - TZ=Asia/Kolkata
 
       - DB_ADAPTER=mysql2
+      - DB_ENCODING=utf8mb4
       - DB_HOST=database
       - DB_PORT=3306
       - DB_USER=redmine

--- a/docker-compose-mysql.yml
+++ b/docker-compose-mysql.yml
@@ -7,6 +7,8 @@ services:
       - DB_USER=redmine
       - DB_PASS=password
       - DB_NAME=redmine_production
+      - MYSQL_CHARSET=utf8mb4
+      - MYSQL_COLLATION=utf8mb4_unicode_ci
     volumes:
       - /srv/docker/redmine/mysql:/var/lib/mysql
     # https://www.redmine.org/projects/redmine/wiki/MySQL_configuration
@@ -21,6 +23,7 @@ services:
       - TZ=Asia/Kolkata
 
       - DB_ADAPTER=mysql2
+      - DB_ENCODING=utf8mb4
       - DB_HOST=mysql
       - DB_PORT=3306
       - DB_USER=redmine


### PR DESCRIPTION
The 4 byte utf8 implementation is needed to support all unicode characters. Otherwise only a subset of them are usable.

Using utf8mb4 fixes
* server errrors when entering an invalid character in the web ui
* the email importer silently dropping mails in case a mail contained an invalid character

Note:
The database (in this case only applies to mariadb and mysql) also needs to be adjusted accordingly.