### PR TITLE
speed up ensuring correct file-permissions are set

### DIFF
--- a/assets/runtime/functions
+++ b/assets/runtime/functions
@@ -789,28 +789,6 @@ initialize_logdir() {
 
 initialize_datadir() {
   echo "Initializing datadir..."
-  chmod -R u+rw,go+r ${REDMINE_DATA_DIR}
-  chown -R ${REDMINE_USER}: ${REDMINE_DATA_DIR}
-
-  # create plugins directory
-  mkdir -p ${REDMINE_PLUGINS_DIR}
-  chmod -R u+rw,go+r ${REDMINE_PLUGINS_DIR}
-  chown -R ${REDMINE_USER}: ${REDMINE_PLUGINS_DIR}
-
-  # create themes directory
-  mkdir -p ${REDMINE_THEMES_DIR}
-  chmod -R u+rw,go+r ${REDMINE_THEMES_DIR}
-  chown -R ${REDMINE_USER}: ${REDMINE_THEMES_DIR}
-
-  # create attachments directory
-  mkdir -p ${REDMINE_ATTACHMENTS_DIR}
-  chmod -R u+rw,go+r ${REDMINE_ATTACHMENTS_DIR}
-  chown -R ${REDMINE_USER}: ${REDMINE_ATTACHMENTS_DIR}
-
-  # create backups directory
-  mkdir -p ${REDMINE_BACKUPS_DIR}
-  chmod -R u+rw,go+r ${REDMINE_BACKUPS_DIR}
-  chown -R ${REDMINE_USER}: ${REDMINE_BACKUPS_DIR}
 
   if [[ -d /redmine/files ]]; then # deprecated
     echo "WARNING: "
@@ -819,23 +797,27 @@ initialize_datadir() {
     exit 1
   fi
 
-  # create dotfiles directory
-  mkdir -p ${REDMINE_DOTFILES_DIR}
-  chmod -R u+rw,go+r ${REDMINE_DOTFILES_DIR}
-  chown -R ${REDMINE_USER}: ${REDMINE_DOTFILES_DIR}
+  # create relevant folders and/or fix permissions
+  datafolders=(
+    "${REDMINE_DATA_DIR}"
+    "${REDMINE_PLUGINS_DIR}"
+    "${REDMINE_THEMES_DIR}"
+    "${REDMINE_ATTACHMENTS_DIR}"
+    "${REDMINE_BACKUPS_DIR}"
+    "${REDMINE_DOTFILES_DIR}"
+    "${REDMINE_DOTFILES_DIR}/.subversion"
+    "${REDMINE_DATA_DIR}/tmp"
+  )
+  for dir in "${datafolders[@]}"; do
+    mkdir -p "${dir}"
+    chmod -R u+rw,go+r "${dir}"
+    chown -R ${REDMINE_USER}: "${dir}"
+  done
 
+  # special permissions for ~/.ssh
   mkdir -p ${REDMINE_DOTFILES_DIR}/.ssh
   chmod -R u+rw,go-rwx ${REDMINE_DOTFILES_DIR}/.ssh
   chown -R ${REDMINE_USER}: ${REDMINE_DOTFILES_DIR}/.ssh
-
-  mkdir -p ${REDMINE_DOTFILES_DIR}/.subversion
-  chmod -R u+rw,go+r ${REDMINE_DOTFILES_DIR}/.subversion
-  chown -R ${REDMINE_USER}: ${REDMINE_DOTFILES_DIR}/.subversion
-
-  # create tmp directory
-  mkdir -p ${REDMINE_DATA_DIR}/tmp
-  chmod -R u+rw,go+r ${REDMINE_DATA_DIR}/tmp
-  chown -R ${REDMINE_USER}: ${REDMINE_DATA_DIR}/tmp
 }
 
 generate_ssh_client_keys() {

--- a/assets/runtime/functions
+++ b/assets/runtime/functions
@@ -810,8 +810,8 @@ initialize_datadir() {
   )
   for dir in "${datafolders[@]}"; do
     mkdir -p "${dir}"
-    chmod -R u+rw,go+r "${dir}"
-    chown -R ${REDMINE_USER}: "${dir}"
+    find "${dir}" \! -perm -u=wr,go=r -print0 | xargs -0 -r chmod u+rw,go+r
+    find "${dir}" \! -user ${REDMINE_USER} -print0 | xargs -0 -r chown ${REDMINE_USER}:
   done
 
   # special permissions for ~/.ssh


### PR DESCRIPTION
During each container start the permissions for all relevant files are changed to have write-permission. For large data folders this will delay startup. Changing the permissions always also updates ctime of the file, which will trigger external backup solutions to include all files, even the content did not change.

This PR will check for incorrect permissions via "find" and only updated these files.