### PR TITLE
Make auto db creation optional with DB_CREATE

### DIFF
--- a/README.md
+++ b/README.md
@@ -622,6 +622,7 @@ Below is the complete list of parameters that can be set using environment varia
 - **REDMINE_AVATAR_SERVER_URL**: Avatar server for displaying user icons. Defaults to `https://www.gravatar.com`
 - **DATABASE_URL**: The database URL. See [Configuring a Database](https://guides.rubyonrails.org/configuring.html#configuring-a-database). Possible schemes: `postgres`, `postgresql`, `mysql2`, and `sqlite3`. Defaults to no URL.
 - **DB_ADAPTER**: The database type. Possible values: `mysql2`, `postgresql`, and 'sqlite3'. Defaults to `mysql`.
+- **DB_CREATE**: Whether the db should be automatically created (`bundle exec rake db:create`). Defaults to `true`.
 - **DB_ENCODING**: The database encoding. For `DB_ADAPTER` values `postresql` and `mysql2`, this parameter defaults to `unicode` and `utf8` respectively. For full unicode support (all emojis) with mariadb or mysql set this to `utf8mb4` and make sure to also set all tables to `utf8mb4` and use `collate utf8mb4_unicode_ci`. Existing databases can be converted by following this [HowTo](https://www.redmine.org/projects/redmine/wiki/HowTo_convert_a_database_from_utf8_to_utf8mb4).
 - **DB_HOST**: The database server hostname. Defaults to `localhost`.
 - **DB_PORT**: The database server port. Defaults to `3306`.

--- a/assets/runtime/functions
+++ b/assets/runtime/functions
@@ -1048,8 +1048,27 @@ migrate_database() {
   CACHE_VERSION=
   [[ -f ${REDMINE_DATA_DIR}/tmp/VERSION ]] && CACHE_VERSION=$(cat ${REDMINE_DATA_DIR}/tmp/VERSION)
   if [[ ${REDMINE_VERSION} != ${CACHE_VERSION} ]]; then
+    if [[ "${DB_CREATE:-true}" == "true" ]] ; then
+      echo "Creating database..."
+      # Disable "exit on error" so we can capture the error code
+      set +e
+      exec_as_redmine bundle exec rake db:create >/dev/null
+      res=$?
+      # Restore "exit on error"
+      set -e
+
+      if [[ 0 -ne $res ]] ; then
+        echo <<-EOM
+Failed to create db. If db exists, and user (or role) exists and has access to db but no permission to create databases, set:
+-----------------------
+DB_CREATE=false
+-----------------------
+EOM
+        return $res
+      fi
+    fi
+
     echo "Migrating database. Please be patient, this could take a while..."
-    exec_as_redmine bundle exec rake db:create >/dev/null
     exec_as_redmine bundle exec rake db:migrate >/dev/null
 
     # clear sessions and application cache


### PR DESCRIPTION
Added a `DB_CREATE` option (default `true`) to allow skipping the call to `bundle exec rake db:create`. Particularly important for connecting to databases where the user doesn't have permission to create databases.