### PR TITLE
Enable multiplatform build (add arm support)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,9 @@ jobs:
             # set latest tag for default branch
             type=raw,value=latest,enable={{is_default_branch}}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3.0.0
@@ -72,6 +75,7 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
 
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
Based on issue https://github.com/sameersbn/docker-redmine/issues/510

Since used base image (ruby) has arm support it's pretty easy to add arm support here too. Setup QEMU and specify supported platforms.

Tested on my m1 machine:

![изображение](https://github.com/sameersbn/docker-redmine/assets/74700646/3eee074d-a932-4ca1-af6f-092c1d8c576a)

Not only through docker cli, but ui is working fine too.

For debugging i published image on my docker hub account through my fork of this repo. You can check it too if you want to:
https://hub.docker.com/r/siberianlove/redmine/tags