### PR TITLE
Docker-compose.yml: `version` is obsolete

### DIFF
--- a/docker-compose-mariadb.yml
+++ b/docker-compose-mariadb.yml
@@ -1,5 +1,3 @@
-version: '2'
-
 services:
   database:
     image: mariadb:11.2

--- a/docker-compose-memcached.yml
+++ b/docker-compose-memcached.yml
@@ -1,5 +1,3 @@
-version: '2'
-
 services:
   postgresql:
     image: sameersbn/postgresql:14-20230628

--- a/docker-compose-mysql.yml
+++ b/docker-compose-mysql.yml
@@ -1,5 +1,3 @@
-version: '2'
-
 services:
   mysql:
     image: sameersbn/mysql:5.7.22-1

--- a/docker-compose-sqlite3.yml
+++ b/docker-compose-sqlite3.yml
@@ -1,5 +1,3 @@
-version: '2'
-
 services:
   redmine:
     build: ./

--- a/docker-compose-ssl.yml
+++ b/docker-compose-ssl.yml
@@ -1,5 +1,3 @@
-version: '2'
-
 services:
   postgresql:
     image: sameersbn/postgresql:14-20230628

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '2.3'
-
 services:
   postgresql:
     image: sameersbn/postgresql:14-20230628


### PR DESCRIPTION
Read [[BUG] 'version' is obsolete](https://github.com/docker/compose/issues/11628)