### PR TITLE
functions: set flag "REDMINE_WAS_UPDATED" when a redmine-upgrade was done

### DIFF
--- a/README.md
+++ b/README.md
@@ -983,6 +983,8 @@ Replace `x.x.x` with the version you are upgrading from. For example, if you are
 docker run --name=redmine -d [OPTIONS] sameersbn/redmine:5.1.3
 ```
 
+When an upgrade is in progress the variable `REDMINE_WAS_UPDATED` will be defined and set to `yes`.  This allows easy integration of individual upgrade-steps via `entrypoint.custom.sh`.
+
 ## Shell Access
 
 For debugging and maintenance purposes you may want access the containers shell. If you are using docker version `1.3.0` or higher you can access a running containers shell using `docker exec` command.

--- a/assets/runtime/functions
+++ b/assets/runtime/functions
@@ -1058,6 +1058,7 @@ migrate_database() {
 
     # Now that database has been migrated, update version file
     echo ${REDMINE_VERSION} | exec_as_redmine tee --append ${REDMINE_DATA_DIR}/tmp/VERSION >/dev/null
+    export REDMINE_WAS_UPDATED=yes
   fi
 }
 


### PR DESCRIPTION
For a custom plugin I need to know when the REDMINE-version was upgraded, to trigger some additional maintenance via `entrypoint.custom.sh`.
Setting the variable REDMINE_WAS_UPDATED=yes will allow my custom-entrypoint to detect such upgrade.