### PR TITLE
Fix DATABASE_URL support

### DIFF
--- a/assets/runtime/functions
+++ b/assets/runtime/functions
@@ -190,13 +190,14 @@ redmine_finalize_database_parameters() {
     DB_PASS=${DB_PASS:-${POSTGRESQL_ENV_PASS}}
     DB_NAME=${DB_NAME:-${POSTGRESQL_ENV_DB}}
   elif [[ -n ${DATABASE_URL} ]]; then
-    # Set environments for redmine_check_database_connection
     case $(ruby -r uri -e 'puts URI(ENV["DATABASE_URL"]).scheme') in
       postgres | postgresql)
         DB_ADAPTER=${DB_ADAPTER:-postgresql}
         DB_HOST=${DB_HOST:-$(ruby -r uri -e 'puts URI(ENV["DATABASE_URL"]).hostname')}
         DB_PORT=${DB_PORT:-$(ruby -r uri -e 'puts URI(ENV["DATABASE_URL"]).port || 5432')}
         DB_USER=${DB_USER:-$(ruby -r uri -e 'puts URI(ENV["DATABASE_URL"]).user')}
+        DB_PASS=${DB_PASS:-$(ruby -r uri -e 'puts URI(ENV["DATABASE_URL"]).password')}
+        DB_NAME=${DB_NAME:-$(ruby -r uri -e 'puts URI(ENV["DATABASE_URL"]).path.delete_prefix("/")')}
         ;;
       mysql2)
         DB_ADAPTER=${DB_ADAPTER:-mysql2}
@@ -204,6 +205,7 @@ redmine_finalize_database_parameters() {
         DB_PORT=${DB_PORT:-$(ruby -r uri -e 'puts URI(ENV["DATABASE_URL"]).port || 3306')}
         DB_USER=${DB_USER:-$(ruby -r uri -e 'puts URI(ENV["DATABASE_URL"]).user')}
         DB_PASS=${DB_PASS:-$(ruby -r uri -e 'puts URI(ENV["DATABASE_URL"]).password')}
+        DB_NAME=${DB_NAME:-$(ruby -r uri -e 'puts URI(ENV["DATABASE_URL"]).path.delete_prefix("/")')}
         ;;
       sqlite3)
         DB_ADAPTER=${DB_ADAPTER:-sqlite3}


### PR DESCRIPTION
Because this script updates `config/database.yml`, it also need to set `DB_PASS` and `DB_NAME`.

Without this, `config/database.yml` includes `password: ''` and `database: redmine_production` (that does not match `DATABASE_URL`), and I see following errors.

```
[4fe1db4e-b38a-4e67-bfb2-049dbfea712d] ActiveRecord::ConnectionNotEstablished (connection to server at "172.17.0.2", port 5432 failed: fe_sendauth: no password supplied
):
[4fe1db4e-b38a-4e67-bfb2-049dbfea712d] 
Causes:
[4fe1db4e-b38a-4e67-bfb2-049dbfea712d] PG::ConnectionBad (connection to server at "172.17.0.2", port 5432 failed: fe_sendauth: no password supplied
)
``