### PR TITLE
FIX: Use a recursive chown instead of a find when changing redmine uid

### DIFF
--- a/assets/runtime/functions
+++ b/assets/runtime/functions
@@ -845,7 +845,7 @@ map_uidgid() {
     echo "Mapping UID and GID for ${REDMINE_USER}:${REDMINE_USER} to $USERMAP_UID:$USERMAP_GID"
     groupmod -g ${USERMAP_GID} ${REDMINE_USER}
     sed -i -e "s|:${USERMAP_ORIG_UID}:${USERMAP_GID}:|:${USERMAP_UID}:${USERMAP_GID}:|" /etc/passwd
-    find ${REDMINE_HOME} -path ${REDMINE_DATA_DIR}/\* -prune -o -print0 | xargs -0 chown -h ${REDMINE_USER}:
+	chown -R ${REDMINE_USER}: ${REDMINE_HOME}/${REDMINE_DATA_DIR}
   fi
 }
 


### PR DESCRIPTION
Hi,

This updates a single line in `assets/runtime/functions`, where a find |xargs was used to perform a chown. This find alone is somehow taking more than 3 minutes to boot my dockerized Redmine.
I can't see an obvious reason to have done it this way instead of a simple `chown -R` but I don't have your full history. Maybe I missed something!

Best regards,