### PR TITLE
functions: Fix fetch commits cron job

### DIFF
--- a/assets/runtime/functions
+++ b/assets/runtime/functions
@@ -599,7 +599,7 @@ redmine_configure_fetch_commits() {
           2.*)
             echo "@${REDMINE_FETCH_COMMITS} cd ${REDMINE_HOME}/redmine && ./script/rails runner \"Repository.fetch_changesets\" -e ${RAILS_ENV} >> ${REDMINE_LOG_DIR}/redmine/cron_rake.log 2>&1" >>/tmp/cron.${REDMINE_USER}
             ;;
-          3.*|4.*|5.*)
+          3.*|4.*|5.*|6.*)
             echo "@${REDMINE_FETCH_COMMITS} cd ${REDMINE_HOME}/redmine && ./bin/rails runner \"Repository.fetch_changesets\" -e ${RAILS_ENV} >> ${REDMINE_LOG_DIR}/redmine/cron_rake.log 2>&1" >>/tmp/cron.${REDMINE_USER}
             ;;
           *)

--- a/assets/runtime/functions
+++ b/assets/runtime/functions
@@ -595,18 +595,7 @@ redmine_configure_fetch_commits() {
       crontab -u ${REDMINE_USER} -l >/tmp/cron.${REDMINE_USER}
       if ! grep -q 'Repository.fetch_changesets' /tmp/cron.${REDMINE_USER}; then
         echo "Configuring redmine::fetch_commits..."
-        case ${REDMINE_VERSION} in
-          2.*)
-            echo "@${REDMINE_FETCH_COMMITS} cd ${REDMINE_HOME}/redmine && ./script/rails runner \"Repository.fetch_changesets\" -e ${RAILS_ENV} >> ${REDMINE_LOG_DIR}/redmine/cron_rake.log 2>&1" >>/tmp/cron.${REDMINE_USER}
-            ;;
-          3.*|4.*|5.*|6.*)
-            echo "@${REDMINE_FETCH_COMMITS} cd ${REDMINE_HOME}/redmine && ./bin/rails runner \"Repository.fetch_changesets\" -e ${RAILS_ENV} >> ${REDMINE_LOG_DIR}/redmine/cron_rake.log 2>&1" >>/tmp/cron.${REDMINE_USER}
-            ;;
-          *)
-            echo "ERROR: Unsupported Redmine version (${REDMINE_VERSION})"
-            return 1
-            ;;
-        esac
+        echo "@${REDMINE_FETCH_COMMITS} cd ${REDMINE_HOME}/redmine && ./bin/rails runner \"Repository.fetch_changesets\" -e ${RAILS_ENV} >> ${REDMINE_LOG_DIR}/redmine/cron_rake.log 2>&1" >>/tmp/cron.${REDMINE_USER}
         crontab -u ${REDMINE_USER} /tmp/cron.${REDMINE_USER}
       fi
       rm -rf /tmp/cron.${REDMINE_USER}


### PR DESCRIPTION
I have the same issue described in #526, except that I'm upgrading from 5.* to 6.*.
```
ERROR: Unsupported Redmine version (6.0.7)
```

In the PR I'm updating the `redmine_configure_fetch_commits` function to handle the case where `${REDMINE_VERSION}` is `6.*`